### PR TITLE
Remove missing make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,14 +25,14 @@ clean:
 
 # Tests...
 #
-test-code: in
+test-code: inplace
 	$(NOSETESTS) -s lightning
 
 test-coverage:
 	$(NOSETESTS) -s --with-coverage --cover-html --cover-html-dir=coverage \
 	--cover-package=lightning lightning
 
-test: test-code test-doc
+test: test-code
 
 # Datasets...
 #


### PR DESCRIPTION
`make all` and `make test` were not working because of this. Is this the intended fix?