### PR TITLE
Add MANIFEST.in to include pxd files in releases

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include MANIFEST.in
+recursive-include lightning *.c *.h *.cpp *.pyx *.pxd

--- a/lightning/impl/setup.py
+++ b/lightning/impl/setup.py
@@ -60,8 +60,8 @@ def configuration(parent_package='', top_path=None):
 
     # add .pxd files to be re-used by third party software
     config.add_data_files('sag_fast.pxd', 'dataset_fast.pxd',
-					      'sgd_fast.pxd', 'prox_fast.pxd')
-	
+                          'sgd_fast.pxd', 'prox_fast.pxd')
+
     return config
 
 if __name__ == '__main__':


### PR DESCRIPTION
I ran 
```
python setup.py sdist
[go to basic venv]
pip install dist/sklearn-contrib-lightning-0.3.dev0.tar.gz
[go to my package]
[regenerate cython files]
[build]
[test]
```

and it worked like a charm.

Side by side diff of the last release vs sdist on this branch.

```
sklearn-contrib-lightning-0.3.dev0/ | sklearn-contrib-lightning-0.2.0/
├── bin                             ├── bin
│   ├── lightning_predict           │   ├── lightning_predict
│   └── lightning_train             │   └── lightning_train
├── lightning                       ├── lightning
│   ├── classification.py           │   ├── classification.py
│   ├── datasets.py                 │   ├── datasets.py
│   ├── impl                        │   ├── impl
│   │   ├── adagrad_fast.cpp        │   │   ├── adagrad_fast.cpp
│   │   ├── adagrad_fast.pyx        <
│   │   ├── adagrad.py              │   │   ├── adagrad.py
│   │   ├── base.py                 │   │   ├── base.py
│   │   ├── dataset_fast.cpp        │   │   ├── dataset_fast.cpp
│   │   ├── dataset_fast.pxd        <
│   │   ├── dataset_fast.pyx        <
│   │   ├── datasets                │   │   ├── datasets
│   │   │   ├── __init__.py         │   │   │   ├── __init__.py
│   │   │   ├── loaders.py          │   │   │   ├── loaders.py
│   │   │   ├── samples_generator.py│   │   │   ├── samples_generator.py
│   │   │   └── utils.py            │   │   │   └── utils.py
│   │   ├── dual_cd_fast.cpp        │   │   ├── dual_cd_fast.cpp
│   │   ├── dual_cd_fast.pyx        <
│   │   ├── dual_cd.py              │   │   ├── dual_cd.py
│   │   ├── fista.py                │   │   ├── fista.py
│   │   ├── __init__.py             │   │   ├── __init__.py
│   │   ├── loss_fast.cpp           │   │   ├── loss_fast.cpp
│   │   ├── loss_fast.pyx           <
│   │   ├── penalty.py              │   │   ├── penalty.py
│   │   ├── prank_fast.cpp          │   │   ├── prank_fast.cpp
│   │   ├── prank_fast.pyx          <
│   │   ├── prank.py                │   │   ├── prank.py
│   │   ├── primal_cd_fast.cpp      │   │   ├── primal_cd_fast.cpp
│   │   ├── primal_cd_fast.pyx      <
│   │   ├── primal_cd.py            │   │   ├── primal_cd.py
│   │   ├── primal_newton.py        │   │   ├── primal_newton.py
│   │   ├── prox_fast.cpp           │   │   ├── prox_fast.cpp
│   │   ├── prox_fast.pxd           <
│   │   ├── prox_fast.pyx           <
│   │   ├── randomkit               │   │   ├── randomkit
│   │   │   ├── __init__.py         │   │   │   ├── __init__.py
│   │   │   ├── random_fast.cpp     │   │   │   ├── random_fast.cpp
│   │   │   ├── random_fast.pxd     <
│   │   │   ├── random_fast.pyx     <
│   │   │   ├── randomkit.c         │   │   │   ├── randomkit.c
│   │   │   ├── randomkit.h         │   │   │   ├── randomkit.h
│   │   │   ├── setup.py            │   │   │   ├── setup.py
│   │   │   └── tests               │   │   │   └── tests
│   │   │       ├── __init__.py     │   │   │       ├── __init__.py
│   │   │       └── test_random.py  │   │   │       └── test_random.py
│   │   ├── sag_fast.cpp            │   │   ├── sag_fast.cpp
│   │   ├── sag_fast.pxd            <
│   │   ├── sag_fast.pyx            <
│   │   ├── sag.py                  │   │   ├── sag.py
│   │   ├── sdca_fast.cpp           │   │   ├── sdca_fast.cpp
│   │   ├── sdca_fast.pyx           <
│   │   ├── sdca.py                 │   │   ├── sdca.py
│   │   ├── setup.py                │   │   ├── setup.py
│   │   ├── sgd_fast.cpp            │   │   ├── sgd_fast.cpp
│   │   ├── sgd_fast.pxd            <
│   │   ├── sgd_fast.pyx            <
│   │   ├── sgd.py                  │   │   ├── sgd.py
│   │   ├── svrg_fast.cpp           │   │   ├── svrg_fast.cpp
│   │   ├── svrg_fast.pyx           <
│   │   ├── svrg.py                 │   │   ├── svrg.py
│   │   └── tests                   │   │   └── tests
│   │       ├── __init__.py         │   │       ├── __init__.py
│   │       ├── test_adagrad.py     │   │       ├── test_adagrad.py
│   │       ├── test_dataset.py     │   │       ├── test_dataset.py
│   │       ├── test_dual_cd.py     │   │       ├── test_dual_cd.py
│   │       ├── test_fista.py       │   │       ├── test_fista.py
│   │       ├── test_prank.py       │   │       ├── test_prank.py
│   │       ├── test_primal_cd.py   │   │       ├── test_primal_cd.py
│   │       ├── test_primal_newton.py│   │       ├── test_primal_newton.py
│   │       ├── test_prox.py        │   │       ├── test_prox.py
│   │       ├── test_sag.py         │   │       ├── test_sag.py
│   │       ├── test_sdca.py        │   │       ├── test_sdca.py
│   │       ├── test_sgd.py         │   │       ├── test_sgd.py
│   │       └── test_svrg.py        │   │       └── test_svrg.py
│   ├── __init__.py                 │   ├── __init__.py
│   ├── ranking.py                  │   ├── ranking.py
│   ├── regression.py               │   ├── regression.py
│   └── setup.py                    │   └── setup.py
├── MANIFEST.in                     <
├── PKG-INFO                        ├── PKG-INFO
├── README.rst                      ├── README.rst
├── setup.cfg                       ├── setup.cfg
├── setup.py                        ├── setup.py
└── sklearn_contrib_lightning.egg-info └── sklearn_contrib_lightning.egg-info
    ├── dependency_links.txt           ├── dependency_links.txt
    ├── not-zip-safe                   ├── not-zip-safe
    ├── PKG-INFO                       ├── PKG-INFO
    ├── SOURCES.txt                    ├── SOURCES.txt
    └── top_level.txt                  └── top_level.txt

8 directories, 84 files                       | 8 directories, 66 files

```