### PR TITLE
raise AttributeError if predict_proba is not available

### DIFF
--- a/lightning/impl/base.py
+++ b/lightning/impl/base.py
@@ -38,11 +38,18 @@ class BaseEstimator(_BaseEstimator):
 
 class BaseClassifier(BaseEstimator, ClassifierMixin):
 
-    def predict_proba(self, X):
-        if len(self.classes_) != 2:
-            raise NotImplementedError("predict_(log_)proba only supported"
-                                      " for binary classification")
+    @property
+    def predict_proba(self):
+        if self.loss not in ("log", "modified_huber"):
+            raise AttributeError("predict_proba only supported when"
+                                 " loss='log' or loss='modified_huber' "
+                                 "(%s given)" % self.loss)
+        return self._predict_proba
 
+    def _predict_proba(self, X):
+        if len(self.classes_) != 2:
+            raise NotImplementedError("predict_proba only supported"
+                                      " for binary classification")
         if self.loss == "log":
             df = self.decision_function(X).ravel()
             prob = 1.0 / (1.0 + np.exp(-df))
@@ -52,7 +59,7 @@ class BaseClassifier(BaseEstimator, ClassifierMixin):
             prob += 1
             prob /= 2
         else:
-            raise NotImplementedError("predict_(log_)proba only supported when"
+            raise NotImplementedError("predict_proba only supported when"
                                       " loss='log' or loss='modified_huber' "
                                       "(%s given)" % self.loss)
 

--- a/lightning/impl/tests/test_adagrad.py
+++ b/lightning/impl/tests/test_adagrad.py
@@ -7,6 +7,7 @@ from sklearn.utils.testing import assert_almost_equal
 from lightning.classification import AdaGradClassifier
 from lightning.regression import AdaGradRegressor
 from lightning.impl.adagrad_fast import _proj_elastic_all
+from lightning.impl.tests.utils import check_predict_proba
 
 iris = load_iris()
 X, y = iris.data, iris.target
@@ -18,6 +19,7 @@ y_bin = y[y <= 1] * 2 - 1
 def test_adagrad_elastic_hinge():
     clf = AdaGradClassifier(alpha=0.5, l1_ratio=0.85, n_iter=10, random_state=0)
     clf.fit(X_bin, y_bin)
+    assert not hasattr(clf, "predict_proba")
     assert_equal(clf.score(X_bin, y_bin), 1.0)
 
 
@@ -25,6 +27,7 @@ def test_adagrad_elastic_smooth_hinge():
     clf = AdaGradClassifier(alpha=0.5, l1_ratio=0.85, loss="smooth_hinge",
                             n_iter=10, random_state=0)
     clf.fit(X_bin, y_bin)
+    assert not hasattr(clf, "predict_proba")
     assert_equal(clf.score(X_bin, y_bin), 1.0)
 
 
@@ -33,11 +36,13 @@ def test_adagrad_elastic_log():
                             random_state=0)
     clf.fit(X_bin, y_bin)
     assert_equal(clf.score(X_bin, y_bin), 1.0)
+    check_predict_proba(clf, X_bin)
 
 
 def test_adagrad_hinge_multiclass():
     clf = AdaGradClassifier(alpha=1e-2, n_iter=100, loss="hinge", random_state=0)
     clf.fit(X, y)
+    assert not hasattr(clf, "predict_proba")
     assert_almost_equal(clf.score(X, y), 0.960, 3)
 
 

--- a/lightning/impl/tests/test_dual_cd.py
+++ b/lightning/impl/tests/test_dual_cd.py
@@ -6,7 +6,6 @@ from sklearn.datasets.samples_generator import make_regression
 from sklearn.externals.six.moves import xrange
 
 from sklearn.utils.testing import assert_equal
-from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import assert_array_almost_equal
 

--- a/lightning/impl/tests/test_primal_cd.py
+++ b/lightning/impl/tests/test_primal_cd.py
@@ -15,6 +15,8 @@ from sklearn.externals.six.moves import xrange
 
 from lightning.impl.datasets.samples_generator import make_classification
 from lightning.impl.primal_cd import CDClassifier, CDRegressor
+from lightning.impl.tests.utils import check_predict_proba
+
 
 bin_dense, bin_target = make_classification(n_samples=200, n_features=100,
                                             n_informative=5,
@@ -31,6 +33,7 @@ digit = load_digits(2)
 def test_fit_linear_binary_l1r():
     clf = CDClassifier(C=1.0, random_state=0, penalty="l1")
     clf.fit(bin_dense, bin_target)
+    assert not hasattr(clf, 'predict_proba')
     acc = clf.score(bin_dense, bin_target)
     assert_almost_equal(acc, 1.0)
     n_nz = clf.n_nonzero()
@@ -51,6 +54,7 @@ def test_fit_linear_binary_l1r():
 def test_fit_linear_binary_l1r_smooth_hinge():
     clf = CDClassifier(C=1.0, loss="smooth_hinge", random_state=0, penalty="l1")
     clf.fit(bin_dense, bin_target)
+    assert not hasattr(clf, 'predict_proba')
     acc = clf.score(bin_dense, bin_target)
     assert_almost_equal(acc, 1.0)
 
@@ -102,6 +106,7 @@ def test_warm_start_l1r_regression():
 def test_fit_linear_binary_l1r_log_loss():
     clf = CDClassifier(C=1.0, random_state=0, penalty="l1", loss="log")
     clf.fit(bin_dense, bin_target)
+    check_predict_proba(clf, bin_dense)
     acc = clf.score(bin_dense, bin_target)
     assert_almost_equal(acc, 0.995)
 
@@ -133,6 +138,7 @@ def test_fit_linear_binary_l2r_modified_huber():
     clf = CDClassifier(C=1.0, random_state=0, penalty="l2",
                        loss="modified_huber")
     clf.fit(bin_dense, bin_target)
+    check_predict_proba(clf, bin_dense)
     acc = clf.score(bin_dense, bin_target)
     assert_almost_equal(acc, 1.0)
 

--- a/lightning/impl/tests/test_sag.py
+++ b/lightning/impl/tests/test_sag.py
@@ -19,6 +19,7 @@ from lightning.impl.sgd_fast import SquaredHinge
 from lightning.impl.sgd_fast import Log
 from lightning.impl.sgd_fast import SquaredLoss
 from lightning.impl.sag import get_auto_step_size
+from lightning.impl.tests.utils import check_predict_proba
 
 
 iris = load_iris()
@@ -211,6 +212,7 @@ def test_sag():
         PySAGClassifier(eta=1e-3, max_iter=20, random_state=0)
             ):
         clf.fit(X_bin, y_bin)
+        assert not hasattr(clf, 'predict_proba')
         assert_equal(clf.score(X_bin, y_bin), 1.0)
         assert_equal(list(clf.classes_), [-1, 1])
 
@@ -244,8 +246,7 @@ def test_sag_proba():
     sag = SAGClassifier(eta=1e-3, alpha=0.0, beta=0.0, max_iter=10,
                         loss='log', random_state=0)
     sag.fit(X, y)
-    probas = sag.predict_proba(X)
-    assert_equal(probas.sum(), n_samples)
+    check_predict_proba(sag, X)
 
 
 def test_sag_multiclass_classes():

--- a/lightning/impl/tests/test_sdca.py
+++ b/lightning/impl/tests/test_sdca.py
@@ -6,6 +6,8 @@ from sklearn.utils.testing import assert_almost_equal
 
 from lightning.classification import SDCAClassifier
 from lightning.regression import SDCARegressor
+from lightning.impl.tests.utils import check_predict_proba
+
 
 iris = load_iris()
 X, y = iris.data, iris.target
@@ -17,6 +19,7 @@ y_bin = y[y <= 1] * 2 - 1
 def test_sdca_hinge():
     clf = SDCAClassifier(loss="hinge", random_state=0)
     clf.fit(X_bin, y_bin)
+    assert not hasattr(clf, 'predict_proba')
     assert_equal(clf.score(X_bin, y_bin), 1.0)
 
 
@@ -30,12 +33,14 @@ def test_sdca_hinge_multiclass():
 def test_sdca_squared():
     clf = SDCAClassifier(loss="squared", random_state=0)
     clf.fit(X_bin, y_bin)
+    assert not hasattr(clf, 'predict_proba')
     assert_equal(clf.score(X_bin, y_bin), 1.0)
 
 
 def test_sdca_absolute():
     clf = SDCAClassifier(loss="absolute", random_state=0)
     clf.fit(X_bin, y_bin)
+    assert not hasattr(clf, 'predict_proba')
     assert_equal(clf.score(X_bin, y_bin), 1.0)
 
 
@@ -50,6 +55,7 @@ def test_sdca_smooth_hinge_elastic():
     clf = SDCAClassifier(alpha=0.5, l1_ratio=0.85, loss="smooth_hinge",
                               random_state=0)
     clf.fit(X_bin, y_bin)
+    assert not hasattr(clf, 'predict_proba')
     assert_equal(clf.score(X_bin, y_bin), 1.0)
 
 

--- a/lightning/impl/tests/test_sgd.py
+++ b/lightning/impl/tests/test_sgd.py
@@ -12,6 +12,7 @@ from lightning.impl.datasets.samples_generator import make_classification
 from lightning.impl.datasets.samples_generator import make_nn_regression
 from lightning.impl.sgd import SGDClassifier
 from lightning.impl.sgd import SGDRegressor
+from lightning.impl.tests.utils import check_predict_proba
 
 
 bin_dense, bin_target = make_classification(n_samples=200, n_features=100,
@@ -24,6 +25,7 @@ mult_dense, mult_target = make_classification(n_samples=300, n_features=100,
 
 bin_csr = sp.csr_matrix(bin_dense)
 mult_csr = sp.csr_matrix(mult_dense)
+
 
 def test_binary_linear_sgd():
     for data in (bin_dense, bin_csr):
@@ -43,10 +45,13 @@ def test_binary_linear_sgd():
                     SGDClassifier(random_state=0, loss="modified_huber",
                                   fit_intercept=True, learning_rate="constant"),
                     ):
-
             clf.fit(data, bin_target)
             assert_greater(clf.score(data, bin_target), 0.934)
             assert_equal(list(clf.classes_), [0, 1])
+            if clf.loss in ('log', 'modified_huber'):
+                check_predict_proba(clf, data)
+            else:
+                assert not hasattr(clf, 'predict_proba')
 
 
 def test_multiclass_sgd():

--- a/lightning/impl/tests/test_svrg.py
+++ b/lightning/impl/tests/test_svrg.py
@@ -19,6 +19,7 @@ y_bin = y[y <= 1] * 2 - 1
 def test_svrg():
     clf = SVRGClassifier(eta=1e-3, max_iter=20, random_state=0, verbose=0)
     clf.fit(X_bin, y_bin)
+    assert not hasattr(clf, 'predict_proba')
     assert_equal(clf.score(X_bin, y_bin), 1.0)
 
 

--- a/lightning/impl/tests/utils.py
+++ b/lightning/impl/tests/utils.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from sklearn.utils.testing import assert_array_equal, assert_equal
+
+
+def check_predict_proba(clf, X):
+    y_pred = clf.predict(X)
+    n_samples = y_pred.shape[0]
+    # normalize negative class to 0 (it is sometimes 0, sometimes -1)
+    y_pred = (y_pred == 1)
+
+    # check that predict_proba result agree with y_true
+    y_proba = clf.predict_proba(X)
+    assert_equal(y_proba.shape, (n_samples, 2))
+    y_proba_best = (y_proba.argmax(axis=1) == 1)
+    assert_array_equal(y_proba_best, y_pred)
+
+    # check that y_proba looks like probability
+    assert not (y_proba > 1).any()
+    assert not (y_proba < 0).any()
+    assert_array_equal(y_proba.sum(axis=1), 1.0)


### PR DESCRIPTION
In scikit-learn when predit_proba method is not available, AttributeError is raised instead of NotImplementedError. In this PR:
- classifiers are changed to follow the same convention;
- removed predict_log_proba mentions because lightning doesn't provide this method;
- added more tests for predict_proba results.
