### PR TITLE
Stepsize update rule changed in fista.py

### DIFF
--- a/lightning/impl/fista.py
+++ b/lightning/impl/fista.py
@@ -116,7 +116,7 @@ class _BaseFista(object):
                 coefx = coef - G / L
                 coefx = penalty.projection(coefx, self.alpha, L)
 
-            t = (1 + np.sqrt(1 + 4 * t_old * t_old) / 2)
+            t = (1 + np.sqrt(1 + 4 * t_old * t_old)) / 2
             coef = coefx + (t_old - 1) / t * (coefx - coefx_old)
             df = safe_sparse_dot(X, coef.T)
 

--- a/lightning/impl/tests/test_fista.py
+++ b/lightning/impl/tests/test_fista.py
@@ -46,14 +46,14 @@ def test_fista_multiclass_l1l2_log_margin():
         clf = FistaClassifier(max_iter=200, penalty="l1/l2", loss="log_margin",
                               multiclass=True)
         clf.fit(data, mult_target)
-        assert_almost_equal(clf.score(data, mult_target), 0.95, 2)
+        assert_almost_equal(clf.score(data, mult_target), 0.9300, 2)
 
 
 def test_fista_multiclass_l1():
     for data in (mult_dense, mult_csr):
         clf = FistaClassifier(max_iter=200, penalty="l1", multiclass=True)
         clf.fit(data, mult_target)
-        assert_almost_equal(clf.score(data, mult_target), 0.98)
+        assert_almost_equal(clf.score(data, mult_target), 0.9767)
 
 
 
@@ -76,7 +76,7 @@ def test_fista_multiclass_l1l2_no_line_search():
         clf = FistaClassifier(max_iter=500, penalty="l1/l2", multiclass=True,
                               max_steps=0)
         clf.fit(data, mult_target)
-        assert_almost_equal(clf.score(data, mult_target), 0.96, 2)
+        assert_almost_equal(clf.score(data, mult_target), 0.9434, 2)
 
 
 def test_fista_multiclass_l1_no_line_search():
@@ -84,7 +84,7 @@ def test_fista_multiclass_l1_no_line_search():
         clf = FistaClassifier(max_iter=500, penalty="l1", multiclass=True,
                               max_steps=0)
         clf.fit(data, mult_target)
-        assert_almost_equal(clf.score(data, mult_target), 0.95, 2)
+        assert_almost_equal(clf.score(data, mult_target), 0.9367, 2)
 
 
 def test_fista_bin_l1():
@@ -105,7 +105,7 @@ def test_fista_multiclass_trace():
     for data in (mult_dense, mult_csr):
         clf = FistaClassifier(max_iter=100, penalty="trace", multiclass=True)
         clf.fit(data, mult_target)
-        assert_almost_equal(clf.score(data, mult_target), 0.98, 2)
+        assert_almost_equal(clf.score(data, mult_target), 0.9634, 2)
 
 
 def test_fista_bin_classes():
@@ -175,7 +175,7 @@ def test_fista_regression_trace():
     Y_pred = reg.predict(X)
     error = (Y_pred - Y).ravel()
     error = np.dot(error, error)
-    assert_almost_equal(error, 77.45, 2)
+    assert_almost_equal(error, 77.4384, 2)
 
 
 def test_fista_custom_prox():

--- a/lightning/impl/tests/test_fista.py
+++ b/lightning/impl/tests/test_fista.py
@@ -46,14 +46,14 @@ def test_fista_multiclass_l1l2_log_margin():
         clf = FistaClassifier(max_iter=200, penalty="l1/l2", loss="log_margin",
                               multiclass=True)
         clf.fit(data, mult_target)
-        assert_almost_equal(clf.score(data, mult_target), 0.9300, 2)
+        assert_almost_equal(clf.score(data, mult_target), 0.93, 2)
 
 
 def test_fista_multiclass_l1():
     for data in (mult_dense, mult_csr):
         clf = FistaClassifier(max_iter=200, penalty="l1", multiclass=True)
         clf.fit(data, mult_target)
-        assert_almost_equal(clf.score(data, mult_target), 0.9767)
+        assert_almost_equal(clf.score(data, mult_target), 0.98, 2)
 
 
 
@@ -76,7 +76,7 @@ def test_fista_multiclass_l1l2_no_line_search():
         clf = FistaClassifier(max_iter=500, penalty="l1/l2", multiclass=True,
                               max_steps=0)
         clf.fit(data, mult_target)
-        assert_almost_equal(clf.score(data, mult_target), 0.9434, 2)
+        assert_almost_equal(clf.score(data, mult_target), 0.94, 2)
 
 
 def test_fista_multiclass_l1_no_line_search():
@@ -84,7 +84,7 @@ def test_fista_multiclass_l1_no_line_search():
         clf = FistaClassifier(max_iter=500, penalty="l1", multiclass=True,
                               max_steps=0)
         clf.fit(data, mult_target)
-        assert_almost_equal(clf.score(data, mult_target), 0.9367, 2)
+        assert_almost_equal(clf.score(data, mult_target), 0.94, 2)
 
 
 def test_fista_bin_l1():
@@ -105,7 +105,7 @@ def test_fista_multiclass_trace():
     for data in (mult_dense, mult_csr):
         clf = FistaClassifier(max_iter=100, penalty="trace", multiclass=True)
         clf.fit(data, mult_target)
-        assert_almost_equal(clf.score(data, mult_target), 0.9634, 2)
+        assert_almost_equal(clf.score(data, mult_target), 0.96, 2)
 
 
 def test_fista_bin_classes():
@@ -175,7 +175,7 @@ def test_fista_regression_trace():
     Y_pred = reg.predict(X)
     error = (Y_pred - Y).ravel()
     error = np.dot(error, error)
-    assert_almost_equal(error, 77.4384, 2)
+    assert_almost_equal(error, 77.44, 2)
 
 
 def test_fista_custom_prox():


### PR DESCRIPTION
According to the original FISTA paper [Beck09].

[Beck09] Beck, Amir, and Marc Teboulle. "A fast iterative shrinkage-thresholding algorithm for linear inverse problems." SIAM journal on imaging sciences 2.1 (2009): 183-202.