### PR TITLE
[MRG] Fix cythonization error in sgd_fast.pyx

### DIFF
--- a/lightning/impl/sgd_fast.pyx
+++ b/lightning/impl/sgd_fast.pyx
@@ -56,8 +56,6 @@ cdef class ModifiedHuber(LossFunction):
 
 cdef class Hinge(LossFunction):
 
-    cdef double threshold
-
     def __init__(self, double threshold=1.0):
         self.threshold = threshold
 
@@ -75,8 +73,6 @@ cdef class Hinge(LossFunction):
 
 
 cdef class SmoothHinge(LossFunction):
-
-    cdef double gamma
 
     def __init__(self, double gamma=1.0):
         self.gamma = gamma  # the larger, the smoother
@@ -105,8 +101,6 @@ cdef class SmoothHinge(LossFunction):
 
 
 cdef class SquaredHinge(LossFunction):
-
-    cdef double threshold
 
     def __init__(self, double threshold=1.0):
         self.threshold = threshold
@@ -156,8 +150,6 @@ cdef class SquaredLoss(LossFunction):
 
 cdef class Huber(LossFunction):
 
-    cdef double c
-
     def __init__(self, double c):
         self.c = c
 
@@ -181,8 +173,6 @@ cdef class Huber(LossFunction):
 
 
 cdef class EpsilonInsensitive(LossFunction):
-
-    cdef double epsilon
 
     def __init__(self, double epsilon):
         self.epsilon = epsilon


### PR DESCRIPTION
Class variables are already defined in the .pxd. I believe this should get rid of intermittent Travis failures.

For more details about the cythonization error, see:
https://github.com/scikit-learn-contrib/lightning/pull/105#issuecomment-276957093