### PR TITLE
[MRG] Continuous integration on Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ sudo: false
 language: python
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
+  - "3.6"
 install:
   # We do this conditionally because it saves us some downloading if the
   # version is the same.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,7 +43,6 @@ install:
   # Update previous packages and install the build and runtime dependencies of the project.
   - conda update --all --yes
   - conda install --quiet --yes numpy scipy cython nose scikit-learn wheel"
-  - conda install --quiet --yes conda-build
   - "%CMD_IN_ENV% python setup.py bdist_wheel bdist_wininst"
 
   - ps: "ls dist"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,26 +9,21 @@ environment:
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\build_tools\\appveyor\\run_with_env.cmd"
 
   matrix:
-    - PYTHON: "C:\\Python27"
-      PYTHON_VERSION: "2.7.8"
+    - PYTHON_VERSION: "2.7.13"
       PYTHON_ARCH: "32"
       MINICONDA: "C:\\Miniconda"
 
-    - PYTHON: "C:\\Python27-x64"
-      PYTHON_VERSION: "2.7.8"
+    - PYTHON_VERSION: "2.7.13"
       PYTHON_ARCH: "64"
       MINICONDA: "C:\\Miniconda-x64"
 
-    - PYTHON: "C:\\Python35"
-      PYTHON_VERSION: "3.5.0"
+    - PYTHON_VERSION: "3.6.0"
       PYTHON_ARCH: "32"
-      MINICONDA: "C:\\Miniconda35"
+      MINICONDA: "C:\\Miniconda36"
 
-    - PYTHON: "C:\\Python35-x64"
-      PYTHON_VERSION: "3.5.0"
+    - PYTHON_VERSION: "3.6.0"
       PYTHON_ARCH: "64"
-      MINICONDA: "C:\\Miniconda35-x64"
-
+      MINICONDA: "C:\\Miniconda36-x64"
 
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,9 +43,7 @@ install:
   # Update previous packages and install the build and runtime dependencies of the project.
   - conda update --all --yes
   - conda install --quiet --yes numpy scipy cython nose scikit-learn wheel"
-  # there seems to be a problem with conda-build 1.21.0 on python27 and win64, avoid this
-  # by using a previous version
-  - conda install --quiet --yes conda-build=1.21.0
+  - conda install --quiet --yes conda-build
   - "%CMD_IN_ENV% python setup.py bdist_wheel bdist_wininst"
 
   - ps: "ls dist"


### PR DESCRIPTION
In appveyor I am a bit confused because the PYTHON env var seems to point to "system" python while MINICONDA points to a conda-installed python, and these are different in the provided build environment, as shown [here](https://www.appveyor.com/docs/build-environment/). Let's see if this works right.