### PR TITLE
[MRG] support float3d in prox_tv1d

### DIFF
--- a/lightning/impl/prox_fast.pxd
+++ b/lightning/impl/prox_fast.pxd
@@ -1,4 +1,5 @@
 
 cimport numpy as np
+from cython cimport floating
 
-cpdef prox_tv1d(np.ndarray[ndim=1, dtype=double] w, double stepsize)
+cpdef prox_tv1d(np.ndarray[ndim=1, dtype=floating] w, floating stepsize)

--- a/lightning/impl/prox_fast.pyx
+++ b/lightning/impl/prox_fast.pyx
@@ -11,8 +11,9 @@ These are some helper functions to compute the proximal operator of some common 
 """
 
 cimport numpy as np
+from cython cimport floating
 
-cpdef prox_tv1d(np.ndarray[ndim=1, dtype=double] w, double stepsize):
+cpdef prox_tv1d(np.ndarray[ndim=1, dtype=floating] w, floating stepsize):
     """
     Computes the proximal operator of the 1-dimensional total variation operator.
 
@@ -35,7 +36,7 @@ cpdef prox_tv1d(np.ndarray[ndim=1, dtype=double] w, double stepsize):
     IEEE Signal Processing Letters (2013)
     """
     cdef long width, k, k0, kplus, kminus
-    cdef double umin, umax, vmin, vmax, twolambda, minlambda
+    cdef floating umin, umax, vmin, vmax, twolambda, minlambda
     width = w.size
 
     # /to avoid invalid memory access to input[0] and invalid lambda values

--- a/lightning/impl/tests/test_prox.py
+++ b/lightning/impl/tests/test_prox.py
@@ -1,4 +1,6 @@
 import numpy as np
+from nose.tools import assert_equal
+
 from lightning.impl import prox_fast
 
 def test_tv1_denoise():
@@ -16,3 +18,13 @@ def test_tv1_denoise():
             prox_fast.prox_tv1d(x, 1.0)
         # check that the solution is flat
         np.testing.assert_allclose(x, x.mean() * np.ones(n_features))
+
+
+def test_tv1d_dtype():
+    # check that prox_tv1d preserve 32bit
+
+    x = np.arange(5)
+    for dtype in (np.float32, np.float64):
+        y = x.astype(dtype, copy=True)
+        prox_fast.prox_tv1d(y, 0.01)
+        assert_equal(y.dtype, dtype)


### PR DESCRIPTION
Use fused types to support float32 in fused lasso (pun intended)