### PR TITLE
[HOTFIX] fix compatibility with new scikit-learn version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
 
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy nose cython scikit-learn
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy nose cython scikit-learn six joblib
   - source activate test-environment
   - make all
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,7 +37,7 @@ install:
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
   - "pip --version"
 
-  - "%CMD_IN_ENV% pip install --timeout=60 numpy scipy cython nose scikit-learn wheel"
+  - "%CMD_IN_ENV% pip install --timeout=60 numpy scipy cython nose scikit-learn wheel six joblib"
   - "%CMD_IN_ENV% python setup.py bdist_wheel bdist_wininst"
 
   - ps: "ls dist"

--- a/benchmarks/bench_amazon7.py
+++ b/benchmarks/bench_amazon7.py
@@ -1,6 +1,6 @@
 import sys
 
-from sklearn.externals import joblib
+import joblib
 
 from lightning.classification import SDCAClassifier
 

--- a/doc/sphinxext/gen_rst.py
+++ b/doc/sphinxext/gen_rst.py
@@ -20,7 +20,7 @@ import gzip
 import posixpath
 import subprocess
 import warnings
-from sklearn.externals import six
+import six
 
 
 # Try Python 2 first, otherwise load from Python 3
@@ -67,7 +67,7 @@ except ImportError:
     pass
 
 
-from sklearn.externals import joblib
+import joblib
 
 ###############################################################################
 # A tee object to redict streams to multiple outputs

--- a/lightning/impl/adagrad.py
+++ b/lightning/impl/adagrad.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from sklearn.utils import check_random_state
 from sklearn.preprocessing import LabelBinarizer
-from sklearn.externals.six.moves import xrange
+from six.moves import xrange
 
 from .base import BaseClassifier, BaseRegressor
 from .dataset_fast import get_dataset

--- a/lightning/impl/datasets/samples_generator.py
+++ b/lightning/impl/datasets/samples_generator.py
@@ -1,6 +1,6 @@
 import numpy as np
 import scipy.sparse as sp
-from sklearn.externals.six.moves import xrange
+from six.moves import xrange
 
 from sklearn.utils.extmath import safe_sparse_dot
 from sklearn.utils import check_random_state

--- a/lightning/impl/dual_cd.py
+++ b/lightning/impl/dual_cd.py
@@ -14,7 +14,7 @@ import numpy as np
 
 from sklearn.preprocessing import LabelBinarizer
 from sklearn.preprocessing import add_dummy_feature
-from sklearn.externals.six.moves import xrange
+from six.moves import xrange
 
 from .base import BaseClassifier, BaseRegressor
 from .dataset_fast import get_dataset

--- a/lightning/impl/fista.py
+++ b/lightning/impl/fista.py
@@ -4,7 +4,7 @@
 import numpy as np
 
 from sklearn.utils.extmath import safe_sparse_dot
-from sklearn.externals.six.moves import xrange
+from six.moves import xrange
 
 from .base import BaseClassifier, BaseRegressor
 

--- a/lightning/impl/primal_cd.py
+++ b/lightning/impl/primal_cd.py
@@ -12,8 +12,8 @@ functions and penalties.
 
 import numpy as np
 
-from sklearn.externals.joblib import Parallel, delayed
-from sklearn.externals.six.moves import xrange
+from joblib import Parallel, delayed
+from six.moves import xrange
 
 from .base import BaseClassifier
 from .base import BaseRegressor

--- a/lightning/impl/primal_newton.py
+++ b/lightning/impl/primal_newton.py
@@ -18,7 +18,7 @@ from sklearn.utils import safe_mask
 from sklearn.preprocessing import LabelBinarizer
 from sklearn.utils import check_random_state
 from sklearn.metrics.pairwise import pairwise_kernels
-from sklearn.externals.six.moves import xrange
+from six.moves import xrange
 
 from .base import BaseClassifier
 

--- a/lightning/impl/randomkit/tests/test_random.py
+++ b/lightning/impl/randomkit/tests/test_random.py
@@ -3,7 +3,7 @@ import numpy as np
 from numpy.testing import (assert_almost_equal, assert_array_equal,
                            assert_equal)
 from lightning.impl.randomkit import RandomState
-from sklearn.externals.six.moves import xrange
+from six.moves import xrange
 
 
 def test_randint():

--- a/lightning/impl/sag.py
+++ b/lightning/impl/sag.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 
-from sklearn.externals.six.moves import xrange
+from six.moves import xrange
 
 from .base import BaseClassifier, BaseRegressor
 from .dataset_fast import get_dataset

--- a/lightning/impl/sdca.py
+++ b/lightning/impl/sdca.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from sklearn.utils import check_random_state
 from sklearn.preprocessing import LabelBinarizer
-from sklearn.externals.six.moves import xrange
+from six.moves import xrange
 
 from .base import BaseClassifier, BaseRegressor
 from .dataset_fast import get_dataset

--- a/lightning/impl/sgd.py
+++ b/lightning/impl/sgd.py
@@ -16,7 +16,7 @@ import numpy as np
 from sklearn.utils import check_random_state
 from sklearn.utils.extmath import safe_sparse_dot
 from sklearn.utils.validation import assert_all_finite
-from sklearn.externals.six.moves import xrange
+from six.moves import xrange
 
 from .base import BaseClassifier
 from .base import BaseRegressor

--- a/lightning/impl/svrg.py
+++ b/lightning/impl/svrg.py
@@ -4,7 +4,7 @@
 import numpy as np
 
 from sklearn.preprocessing import LabelBinarizer
-from sklearn.externals.six.moves import xrange
+from six.moves import xrange
 
 from .base import BaseClassifier, BaseRegressor
 from .dataset_fast import get_dataset

--- a/lightning/impl/tests/test_dataset.py
+++ b/lightning/impl/tests/test_dataset.py
@@ -5,7 +5,7 @@ import scipy.sparse as sp
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_equal
-from sklearn.externals.six.moves import xrange
+from six.moves import xrange
 
 from sklearn.datasets.samples_generator import make_classification
 from sklearn.utils import check_random_state

--- a/lightning/impl/tests/test_dual_cd.py
+++ b/lightning/impl/tests/test_dual_cd.py
@@ -3,7 +3,7 @@ import scipy.sparse as sp
 
 from sklearn.metrics.pairwise import linear_kernel
 from sklearn.datasets.samples_generator import make_regression
-from sklearn.externals.six.moves import xrange
+from six.moves import xrange
 
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_greater

--- a/lightning/impl/tests/test_penalty.py
+++ b/lightning/impl/tests/test_penalty.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from sklearn.utils.testing import (assert_almost_equal,
                                    assert_array_almost_equal)
-from sklearn.externals.six.moves import xrange
+from six.moves import xrange
 
 from lightning.impl.penalty import project_l1_ball, project_simplex
 

--- a/lightning/impl/tests/test_primal_cd.py
+++ b/lightning/impl/tests/test_primal_cd.py
@@ -11,7 +11,7 @@ from sklearn.utils.testing import assert_raises
 from sklearn.datasets import load_digits
 from sklearn.metrics.pairwise import pairwise_kernels
 from sklearn.preprocessing import LabelBinarizer
-from sklearn.externals.six.moves import xrange
+from six.moves import xrange
 
 from lightning.impl.datasets.samples_generator import make_classification
 from lightning.impl.primal_cd import CDClassifier, CDRegressor

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,10 @@ if __name__ == "__main__":
     setup(configuration=configuration,
           name=DISTNAME,
           maintainer=MAINTAINER,
+          install_requires=[
+              'six',
+              'scikit-learn'
+          ],
           include_package_data=True,
           scripts=["bin/lightning_train",
                    "bin/lightning_predict"],


### PR DESCRIPTION
This PR will allow using `lightning` with the latest version (`0.23.0`) of `scikit-learn`.
Right now if you try to upgrade `scikit-learn`, `lightning` fails with the error about that it cannot import neither `joblib` nor `six` because they are no longer exist in `sklearn.externals`:
```
    from lightning.classification import KernelSVC
../../../virtualenv/python3.6.7/lib/python3.6/site-packages/lightning/classification.py:1: in <module>
    from .impl.adagrad import AdaGradClassifier
../../../virtualenv/python3.6.7/lib/python3.6/site-packages/lightning/impl/adagrad.py:8: in <module>
    from sklearn.externals.six.moves import xrange
```

`six` was dropped along with Python 2 support.
https://scikit-learn.org/stable/whats_new/v0.21.html#sklearn-externals

`joblib` is now a dependency:
https://scikit-learn.org/stable/whats_new/v0.21.html#miscellaneous

This PR should be treated as a hotfix, and ideally `lightning` should drop the support of Python 2 with `six` dependency.