### PR TITLE
fix compatibility with scikit-learn by dropping dependency from sklearn.testing

### DIFF
--- a/lightning/impl/datasets/tests/test_samples_generator.py
+++ b/lightning/impl/datasets/tests/test_samples_generator.py
@@ -1,17 +1,15 @@
 import numpy as np
 
-from sklearn.utils.testing import assert_equal
-
 from lightning.impl.datasets.samples_generator import make_nn_regression
 
 
 def test_make_nn_regression():
     X, y, w = make_nn_regression(n_samples=10, n_features=50, n_informative=5)
-    assert_equal(X.shape[0], 10)
-    assert_equal(X.shape[1], 50)
-    assert_equal(y.shape[0], 10)
-    assert_equal(w.shape[0], 50)
-    assert_equal(np.sum(X.data != 0), 10 * 5)
+    assert X.shape[0] == 10
+    assert X.shape[1] == 50
+    assert y.shape[0] == 10
+    assert w.shape[0] == 50
+    assert np.sum(X.data != 0) == 10 * 5
 
     X, y, w = make_nn_regression(n_samples=10, n_features=50, n_informative=50)
-    assert_equal(np.sum(X.data != 0), 10 * 50)
+    assert np.sum(X.data != 0) == 10 * 50

--- a/lightning/impl/randomkit/tests/test_random.py
+++ b/lightning/impl/randomkit/tests/test_random.py
@@ -1,7 +1,6 @@
 import pickle
 import numpy as np
-from numpy.testing import (assert_almost_equal, assert_array_equal,
-                           assert_equal)
+
 from lightning.impl.randomkit import RandomState
 from six.moves import xrange
 
@@ -9,14 +8,14 @@ from six.moves import xrange
 def test_randint():
     rs = RandomState(seed=0)
     vals = [rs.randint(10) for t in xrange(10000)]
-    assert_almost_equal(np.mean(vals), 5.018)
+    np.testing.assert_almost_equal(np.mean(vals), 5.018)
 
 
 def test_shuffle():
     ind = np.arange(10)
     rs = RandomState(seed=0)
     rs.shuffle(ind)
-    assert_array_equal(ind, [2, 8, 4, 9, 1, 6, 7, 3, 0, 5])
+    np.testing.assert_array_equal(ind, [2, 8, 4, 9, 1, 6, 7, 3, 0, 5])
 
 
 def test_random_state_pickle():
@@ -25,4 +24,4 @@ def test_random_state_pickle():
     pickle_rs = pickle.dumps(rs)
     pickle_rs = pickle.loads(pickle_rs)
     pickle_random_integer = pickle_rs.randint(5)
-    assert_equal(random_integer, pickle_random_integer)
+    assert random_integer == pickle_random_integer

--- a/lightning/impl/tests/test_adagrad.py
+++ b/lightning/impl/tests/test_adagrad.py
@@ -1,8 +1,6 @@
 import numpy as np
 
 from sklearn.datasets import load_iris
-from sklearn.utils.testing import assert_equal
-from sklearn.utils.testing import assert_almost_equal
 
 from lightning.classification import AdaGradClassifier
 from lightning.regression import AdaGradRegressor
@@ -20,7 +18,7 @@ def test_adagrad_elastic_hinge():
     clf = AdaGradClassifier(alpha=0.5, l1_ratio=0.85, n_iter=10, random_state=0)
     clf.fit(X_bin, y_bin)
     assert not hasattr(clf, "predict_proba")
-    assert_equal(clf.score(X_bin, y_bin), 1.0)
+    assert clf.score(X_bin, y_bin) == 1.0
 
 
 def test_adagrad_elastic_smooth_hinge():
@@ -28,14 +26,14 @@ def test_adagrad_elastic_smooth_hinge():
                             n_iter=10, random_state=0)
     clf.fit(X_bin, y_bin)
     assert not hasattr(clf, "predict_proba")
-    assert_equal(clf.score(X_bin, y_bin), 1.0)
+    assert clf.score(X_bin, y_bin) == 1.0
 
 
 def test_adagrad_elastic_log():
     clf = AdaGradClassifier(alpha=0.1, l1_ratio=0.85, loss="log", n_iter=10,
                             random_state=0)
     clf.fit(X_bin, y_bin)
-    assert_equal(clf.score(X_bin, y_bin), 1.0)
+    assert clf.score(X_bin, y_bin) == 1.0
     check_predict_proba(clf, X_bin)
 
 
@@ -43,21 +41,21 @@ def test_adagrad_hinge_multiclass():
     clf = AdaGradClassifier(alpha=1e-2, n_iter=100, loss="hinge", random_state=0)
     clf.fit(X, y)
     assert not hasattr(clf, "predict_proba")
-    assert_almost_equal(clf.score(X, y), 0.960, 3)
+    np.testing.assert_almost_equal(clf.score(X, y), 0.960, 3)
 
 
 def test_adagrad_classes_binary():
     clf = AdaGradClassifier()
     assert not hasattr(clf, 'classes_')
     clf.fit(X_bin, y_bin)
-    assert_equal(list(clf.classes_), [-1, 1])
+    assert list(clf.classes_) == [-1, 1]
 
 
 def test_adagrad_classes_multiclass():
     clf = AdaGradClassifier()
     assert not hasattr(clf, 'classes_')
     clf.fit(X, y)
-    assert_equal(list(clf.classes_), [0, 1, 2])
+    assert list(clf.classes_) == [0, 1, 2]
 
 
 def test_adagrad_callback():
@@ -80,7 +78,7 @@ def test_adagrad_callback():
     clf = AdaGradClassifier(alpha=0.5, l1_ratio=0.85, n_iter=10,
                             callback=cb, random_state=0)
     clf.fit(X_bin, y_bin)
-    assert_equal(cb.acc[-1], 1.0)
+    assert cb.acc[-1] == 1.0
 
 
 def test_adagrad_regression():
@@ -88,4 +86,4 @@ def test_adagrad_regression():
         reg = AdaGradRegressor(loss=loss)
         reg.fit(X_bin, y_bin)
         y_pred = np.sign(reg.predict(X_bin))
-        assert_equal(np.mean(y_bin == y_pred), 1.0)
+        assert np.mean(y_bin == y_pred) == 1.0

--- a/lightning/impl/tests/test_dataset.py
+++ b/lightning/impl/tests/test_dataset.py
@@ -2,9 +2,6 @@ import pickle
 import numpy as np
 import scipy.sparse as sp
 
-from sklearn.utils.testing import assert_array_equal
-from sklearn.utils.testing import assert_array_almost_equal
-from sklearn.utils.testing import assert_equal
 from six.moves import xrange
 
 from sklearn.datasets.samples_generator import make_classification
@@ -38,9 +35,9 @@ def test_contiguous_get_row():
     ind = np.arange(X.shape[1])
     for i in xrange(X.shape[0]):
         indices, data, n_nz = cds.get_row(i)
-        assert_array_equal(indices, ind)
-        assert_array_equal(data, X[i])
-        assert_equal(n_nz, X.shape[1])
+        np.testing.assert_array_equal(indices, ind)
+        np.testing.assert_array_equal(data, X[i])
+        assert n_nz == X.shape[1]
 
 
 def test_csr_get_row():
@@ -48,16 +45,16 @@ def test_csr_get_row():
         indices, data, n_nz = csr_ds.get_row(i)
         for jj in xrange(n_nz):
             j = indices[jj]
-            assert_equal(X[i, j], data[jj])
+            assert X[i, j] == data[jj]
 
 
 def test_fortran_get_column():
     ind = np.arange(X.shape[0])
     for j in xrange(X.shape[1]):
         indices, data, n_nz = fds.get_column(j)
-        assert_array_equal(indices, ind)
-        assert_array_equal(data, X[:, j])
-        assert_equal(n_nz, X.shape[0])
+        np.testing.assert_array_equal(indices, ind)
+        np.testing.assert_array_equal(data, X[:, j])
+        assert n_nz == X.shape[0]
 
 
 def test_csc_get_column():
@@ -65,7 +62,7 @@ def test_csc_get_column():
         indices, data, n_nz = csc_ds.get_column(j)
         for ii in xrange(n_nz):
             i = indices[ii]
-            assert_equal(X[i, j], data[ii])
+            assert X[i, j] == data[ii]
 
 
 def test_picklable_datasets():
@@ -74,5 +71,5 @@ def test_picklable_datasets():
     for dataset in [cds, csr_ds, fds, csc_ds]:
         pds = pickle.dumps(dataset)
         dataset = pickle.loads(pds)
-        assert_equal(dataset.get_n_samples(), X.shape[0])
-        assert_equal(dataset.get_n_features(), X.shape[1])
+        assert dataset.get_n_samples() == X.shape[0]
+        assert dataset.get_n_features() == X.shape[1]

--- a/lightning/impl/tests/test_dual_cd.py
+++ b/lightning/impl/tests/test_dual_cd.py
@@ -5,10 +5,6 @@ from sklearn.metrics.pairwise import linear_kernel
 from sklearn.datasets.samples_generator import make_regression
 from six.moves import xrange
 
-from sklearn.utils.testing import assert_equal
-from sklearn.utils.testing import assert_greater
-from sklearn.utils.testing import assert_array_almost_equal
-
 from lightning.impl.datasets.samples_generator import make_classification
 from lightning.impl.dual_cd import LinearSVC
 from lightning.impl.dual_cd import LinearSVR
@@ -40,7 +36,7 @@ def test_sparse_dot():
                 K2[i, j] = sparse_dot(ds, i, j)
                 K2[j, i] = K[i, j]
 
-    assert_array_almost_equal(K, K2)
+    np.testing.assert_array_almost_equal(K, K2)
 
 
 def test_fit_linear_binary():
@@ -48,8 +44,8 @@ def test_fit_linear_binary():
         for loss in ("l1", "l2"):
             clf = LinearSVC(loss=loss, random_state=0, max_iter=10)
             clf.fit(data, bin_target)
-            assert_equal(list(clf.classes_), [0, 1])
-            assert_equal(clf.score(data, bin_target), 1.0)
+            assert list(clf.classes_) == [0, 1]
+            assert clf.score(data, bin_target) == 1.0
             y_pred = clf.decision_function(data).ravel()
 
 
@@ -59,17 +55,17 @@ def test_fit_linear_binary_auc():
             clf = LinearSVC(loss=loss, criterion="auc", random_state=0,
                             max_iter=25)
             clf.fit(data, bin_target)
-            assert_equal(clf.score(data, bin_target), 1.0)
+            assert clf.score(data, bin_target) == 1.0
 
 
 def test_fit_linear_multi():
     for data in (mult_dense, mult_sparse):
         clf = LinearSVC(random_state=0)
         clf.fit(data, mult_target)
-        assert_equal(list(clf.classes_), [0, 1, 2])
+        assert list(clf.classes_) == [0, 1, 2]
         y_pred = clf.predict(data)
         acc = np.mean(y_pred == mult_target)
-        assert_greater(acc, 0.85)
+        assert acc > 0.85
 
 
 def test_warm_start():
@@ -79,32 +75,32 @@ def test_warm_start():
 
         clf.fit(bin_dense, bin_target)
         acc = clf.score(bin_dense, bin_target)
-        assert_greater(acc, 0.99)
+        assert acc > 0.99
 
 
 def test_linear_svr():
     reg = LinearSVR(random_state=0)
     reg.fit(reg_dense, reg_target)
-    assert_greater(reg.score(reg_dense, reg_target), 0.99)
+    assert reg.score(reg_dense, reg_target) > 0.99
 
 
 def test_linear_svr_fit_intercept():
     reg = LinearSVR(random_state=0, fit_intercept=True)
     reg.fit(reg_dense, reg_target)
-    assert_greater(reg.score(reg_dense, reg_target), 0.99)
+    assert reg.score(reg_dense, reg_target) > 0.99
 
 
 def test_linear_svr_l2():
     reg = LinearSVR(loss="l2", random_state=0)
     reg.fit(reg_dense, reg_target)
-    assert_greater(reg.score(reg_dense, reg_target), 0.99)
+    assert reg.score(reg_dense, reg_target) > 0.99
 
 
 def test_linear_svr_warm_start():
     reg = LinearSVR(C=1e-3, random_state=0, warm_start=True)
     reg.fit(reg_dense, reg_target)
-    assert_greater(reg.score(reg_dense, reg_target), 0.96)
+    assert reg.score(reg_dense, reg_target) > 0.96
 
     reg.C = 1
     reg.fit(reg_dense, reg_target)
-    assert_greater(reg.score(reg_dense, reg_target), 0.99)
+    assert reg.score(reg_dense, reg_target) > 0.99

--- a/lightning/impl/tests/test_fista.py
+++ b/lightning/impl/tests/test_fista.py
@@ -3,10 +3,6 @@ import scipy.sparse as sp
 
 from scipy.linalg import svd, diagsvd
 
-from sklearn.utils.testing import assert_almost_equal
-from sklearn.utils.testing import assert_true
-from sklearn.utils.testing import assert_equal
-
 from sklearn.datasets import load_digits
 
 from lightning.impl.datasets.samples_generator import make_classification
@@ -31,7 +27,7 @@ def test_fista_multiclass_l1l2():
     for data in (mult_dense, mult_csr):
         clf = FistaClassifier(max_iter=200, penalty="l1/l2", multiclass=True)
         clf.fit(data, mult_target)
-        assert_almost_equal(clf.score(data, mult_target), 0.99, 2)
+        np.testing.assert_almost_equal(clf.score(data, mult_target), 0.99, 2)
 
 
 def test_fista_multiclass_l1l2_log():
@@ -39,21 +35,21 @@ def test_fista_multiclass_l1l2_log():
         clf = FistaClassifier(max_iter=200, penalty="l1/l2", loss="log",
                               multiclass=True)
         clf.fit(data, mult_target)
-        assert_almost_equal(clf.score(data, mult_target), 0.90, 2)
+        np.testing.assert_almost_equal(clf.score(data, mult_target), 0.90, 2)
 
 def test_fista_multiclass_l1l2_log_margin():
     for data in (mult_dense, mult_csr):
         clf = FistaClassifier(max_iter=200, penalty="l1/l2", loss="log_margin",
                               multiclass=True)
         clf.fit(data, mult_target)
-        assert_almost_equal(clf.score(data, mult_target), 0.93, 2)
+        np.testing.assert_almost_equal(clf.score(data, mult_target), 0.93, 2)
 
 
 def test_fista_multiclass_l1():
     for data in (mult_dense, mult_csr):
         clf = FistaClassifier(max_iter=200, penalty="l1", multiclass=True)
         clf.fit(data, mult_target)
-        assert_almost_equal(clf.score(data, mult_target), 0.98, 2)
+        np.testing.assert_almost_equal(clf.score(data, mult_target), 0.98, 2)
 
 
 
@@ -61,7 +57,7 @@ def test_fista_multiclass_tv1d():
     for data in (mult_dense, mult_csr):
         clf = FistaClassifier(max_iter=200, penalty="tv1d", multiclass=True)
         clf.fit(data, mult_target)
-        assert_almost_equal(clf.score(data, mult_target), 0.97, 2)
+        np.testing.assert_almost_equal(clf.score(data, mult_target), 0.97, 2)
 
         # adding a lot of regularization coef_ should be constant
         clf = FistaClassifier(max_iter=200, penalty="tv1d", multiclass=True, alpha=1e6)
@@ -76,7 +72,7 @@ def test_fista_multiclass_l1l2_no_line_search():
         clf = FistaClassifier(max_iter=500, penalty="l1/l2", multiclass=True,
                               max_steps=0)
         clf.fit(data, mult_target)
-        assert_almost_equal(clf.score(data, mult_target), 0.94, 2)
+        np.testing.assert_almost_equal(clf.score(data, mult_target), 0.94, 2)
 
 
 def test_fista_multiclass_l1_no_line_search():
@@ -84,47 +80,47 @@ def test_fista_multiclass_l1_no_line_search():
         clf = FistaClassifier(max_iter=500, penalty="l1", multiclass=True,
                               max_steps=0)
         clf.fit(data, mult_target)
-        assert_almost_equal(clf.score(data, mult_target), 0.94, 2)
+        np.testing.assert_almost_equal(clf.score(data, mult_target), 0.94, 2)
 
 
 def test_fista_bin_l1():
     for data in (bin_dense, bin_csr):
         clf = FistaClassifier(max_iter=200, penalty="l1")
         clf.fit(data, bin_target)
-        assert_almost_equal(clf.score(data, bin_target), 1.0, 2)
+        np.testing.assert_almost_equal(clf.score(data, bin_target), 1.0, 2)
 
 
 def test_fista_bin_l1_no_line_search():
     for data in (bin_dense, bin_csr):
         clf = FistaClassifier(max_iter=500, penalty="l1", max_steps=0)
         clf.fit(data, bin_target)
-        assert_almost_equal(clf.score(data, bin_target), 1.0, 2)
+        np.testing.assert_almost_equal(clf.score(data, bin_target), 1.0, 2)
 
 
 def test_fista_multiclass_trace():
     for data in (mult_dense, mult_csr):
         clf = FistaClassifier(max_iter=100, penalty="trace", multiclass=True)
         clf.fit(data, mult_target)
-        assert_almost_equal(clf.score(data, mult_target), 0.96, 2)
+        np.testing.assert_almost_equal(clf.score(data, mult_target), 0.96, 2)
 
 
 def test_fista_bin_classes():
     clf = FistaClassifier()
     clf.fit(bin_dense, bin_target)
-    assert_equal(list(clf.classes_), [0, 1])
+    assert list(clf.classes_) == [0, 1]
 
 
 def test_fista_multiclass_classes():
     clf = FistaClassifier()
     clf.fit(mult_dense, mult_target)
-    assert_equal(list(clf.classes_), [0, 1, 2])
+    assert list(clf.classes_) == [0, 1, 2]
 
 
 def test_fista_regression():
     reg = FistaRegressor(max_iter=100, verbose=0)
     reg.fit(bin_dense, bin_target)
     y_pred = np.sign(reg.predict(bin_dense))
-    assert_almost_equal(np.mean(bin_target == y_pred), 0.985)
+    np.testing.assert_almost_equal(np.mean(bin_target == y_pred), 0.985)
 
 
 def test_fista_regression_simplex():
@@ -137,9 +133,9 @@ def test_fista_regression_simplex():
     reg.fit(X, y)
     y_pred = reg.predict(X)
     error = np.sqrt(np.mean((y - y_pred) ** 2))
-    assert_almost_equal(error, 0.000, 3)
-    assert_true(np.all(reg.coef_ >= 0))
-    assert_almost_equal(np.sum(reg.coef_), 1.0, 3)
+    np.testing.assert_almost_equal(error, 0.000, 3)
+    assert np.all(reg.coef_ >= 0)
+    np.testing.assert_almost_equal(np.sum(reg.coef_), 1.0, 3)
 
 
 def test_fista_regression_l1_ball():
@@ -153,8 +149,8 @@ def test_fista_regression_l1_ball():
     reg.fit(X, y)
     y_pred = reg.predict(X)
     error = np.sqrt(np.mean((y - y_pred) ** 2))
-    assert_almost_equal(error, 0.000, 3)
-    assert_almost_equal(np.sum(np.abs(reg.coef_)), alpha, 3)
+    np.testing.assert_almost_equal(error, 0.000, 3)
+    np.testing.assert_almost_equal(np.sum(np.abs(reg.coef_)), alpha, 3)
 
 
 def test_fista_regression_trace():
@@ -175,7 +171,7 @@ def test_fista_regression_trace():
     Y_pred = reg.predict(X)
     error = (Y_pred - Y).ravel()
     error = np.dot(error, error)
-    assert_almost_equal(error, 77.44, 2)
+    np.testing.assert_almost_equal(error, 77.44, 2)
 
 
 def test_fista_custom_prox():

--- a/lightning/impl/tests/test_penalty.py
+++ b/lightning/impl/tests/test_penalty.py
@@ -1,7 +1,5 @@
 import numpy as np
 
-from sklearn.utils.testing import (assert_almost_equal,
-                                   assert_array_almost_equal)
 from six.moves import xrange
 
 from lightning.impl.penalty import project_l1_ball, project_simplex
@@ -32,21 +30,21 @@ def test_proj_simplex():
     v = rng.rand(100)
     w = project_simplex(v, z=10)
     w2 = project_simplex_bisection(v, z=10, max_iter=100)
-    assert_array_almost_equal(w, w2, 3)
+    np.testing.assert_array_almost_equal(w, w2, 3)
 
     v = rng.rand(3)
     w = project_simplex(v, z=1)
     w2 = project_simplex_bisection(v, z=1, max_iter=100)
-    assert_array_almost_equal(w, w2, 3)
+    np.testing.assert_array_almost_equal(w, w2, 3)
 
     v = rng.rand(2)
     w = project_simplex(v, z=1)
     w2 = project_simplex_bisection(v, z=1, max_iter=100)
-    assert_array_almost_equal(w, w2, 3)
+    np.testing.assert_array_almost_equal(w, w2, 3)
 
 
 def test_proj_l1_ball():
     rng = np.random.RandomState(0)
     v = rng.randn(100)
     w = project_l1_ball(v, z=50)
-    assert_almost_equal(np.sum(np.abs(w)), 50)
+    np.testing.assert_almost_equal(np.sum(np.abs(w)), 50)

--- a/lightning/impl/tests/test_prank.py
+++ b/lightning/impl/tests/test_prank.py
@@ -1,7 +1,6 @@
 import numpy as np
 
 from sklearn.datasets import load_diabetes
-from sklearn.utils.testing import assert_almost_equal
 
 from lightning.ranking import PRank
 from lightning.ranking import KernelPRank
@@ -14,22 +13,22 @@ y = np.round(y, decimals=-2)
 def test_prank():
     est = PRank(n_iter=10, shuffle=False, random_state=0)
     est.fit(X, y)
-    assert_almost_equal(est.score(X, y), 41.86, 2)
+    np.testing.assert_almost_equal(est.score(X, y), 41.86, 2)
 
     est = PRank(n_iter=10, shuffle=True, random_state=0)
     est.fit(X, y)
-    assert_almost_equal(est.score(X, y), 71.04, 2)
+    np.testing.assert_almost_equal(est.score(X, y), 71.04, 2)
 
 
 def test_prank_linear_kernel():
     est = KernelPRank(kernel="linear", n_iter=10, shuffle=False,
                       random_state=0)
     est.fit(X, y)
-    assert_almost_equal(est.score(X, y), 41.86, 2)
+    np.testing.assert_almost_equal(est.score(X, y), 41.86, 2)
 
 
 def test_prank_rbf_kernel():
     est = KernelPRank(kernel="rbf", gamma=100, n_iter=10, shuffle=False,
                       random_state=0)
     est.fit(X, y)
-    assert_almost_equal(est.score(X, y), 15.84, 2)
+    np.testing.assert_almost_equal(est.score(X, y), 15.84, 2)

--- a/lightning/impl/tests/test_primal_cd.py
+++ b/lightning/impl/tests/test_primal_cd.py
@@ -1,13 +1,6 @@
 import numpy as np
 import scipy.sparse as sp
 
-from sklearn.utils.testing import assert_array_almost_equal
-from sklearn.utils.testing import assert_almost_equal
-from sklearn.utils.testing import assert_true
-from sklearn.utils.testing import assert_equal
-from sklearn.utils.testing import assert_greater
-from sklearn.utils.testing import assert_raises
-
 from sklearn.datasets import load_digits
 from sklearn.metrics.pairwise import pairwise_kernels
 from sklearn.preprocessing import LabelBinarizer
@@ -35,20 +28,20 @@ def test_fit_linear_binary_l1r():
     clf.fit(bin_dense, bin_target)
     assert not hasattr(clf, 'predict_proba')
     acc = clf.score(bin_dense, bin_target)
-    assert_almost_equal(acc, 1.0)
+    np.testing.assert_almost_equal(acc, 1.0)
     n_nz = clf.n_nonzero()
     perc = clf.n_nonzero(percentage=True)
-    assert_equal(perc, float(n_nz) / bin_dense.shape[1])
+    assert perc == float(n_nz) / bin_dense.shape[1]
 
     clf = CDClassifier(C=0.1, random_state=0, penalty="l1")
     clf.fit(bin_dense, bin_target)
     acc = clf.score(bin_dense, bin_target)
-    assert_almost_equal(acc, 0.97)
+    np.testing.assert_almost_equal(acc, 0.97)
     n_nz2 = clf.n_nonzero()
     perc2 = clf.n_nonzero(percentage=True)
-    assert_equal(perc2, float(n_nz2) / bin_dense.shape[1])
+    assert perc2 == float(n_nz2) / bin_dense.shape[1]
 
-    assert_true(n_nz > n_nz2)
+    assert n_nz > n_nz2
 
 
 def test_fit_linear_binary_l1r_smooth_hinge():
@@ -56,7 +49,7 @@ def test_fit_linear_binary_l1r_smooth_hinge():
     clf.fit(bin_dense, bin_target)
     assert not hasattr(clf, 'predict_proba')
     acc = clf.score(bin_dense, bin_target)
-    assert_almost_equal(acc, 1.0)
+    np.testing.assert_almost_equal(acc, 1.0)
 
 
 def test_fit_linear_binary_l1r_no_linesearch():
@@ -64,7 +57,7 @@ def test_fit_linear_binary_l1r_no_linesearch():
                        random_state=0, penalty="l1")
     clf.fit(bin_dense, bin_target)
     acc = clf.score(bin_dense, bin_target)
-    assert_almost_equal(acc, 1.0)
+    np.testing.assert_almost_equal(acc, 1.0)
 
 
 def test_l1r_shrinking():
@@ -72,7 +65,7 @@ def test_l1r_shrinking():
         clf = CDClassifier(C=0.5, penalty="l1", random_state=0,
                            shrinking=shrinking)
         clf.fit(bin_dense, bin_target)
-        assert_equal(clf.score(bin_dense, bin_target), 1.0)
+        assert clf.score(bin_dense, bin_target) == 1.0
 
 
 def test_warm_start_l1r():
@@ -86,7 +79,7 @@ def test_warm_start_l1r():
     clf.fit(bin_dense, bin_target)
     n_nz2 = clf.n_nonzero()
 
-    assert_true(n_nz < n_nz2)
+    assert n_nz < n_nz2
 
 
 def test_warm_start_l1r_regression():
@@ -100,7 +93,7 @@ def test_warm_start_l1r_regression():
     clf.fit(bin_dense, bin_target)
     n_nz2 = clf.n_nonzero()
 
-    assert_true(n_nz < n_nz2)
+    assert n_nz < n_nz2
 
 
 def test_fit_linear_binary_l1r_log_loss():
@@ -108,7 +101,7 @@ def test_fit_linear_binary_l1r_log_loss():
     clf.fit(bin_dense, bin_target)
     check_predict_proba(clf, bin_dense)
     acc = clf.score(bin_dense, bin_target)
-    assert_almost_equal(acc, 0.995)
+    np.testing.assert_almost_equal(acc, 0.995)
 
 
 def test_fit_linear_binary_l1r_log_loss_no_linesearch():
@@ -116,14 +109,14 @@ def test_fit_linear_binary_l1r_log_loss_no_linesearch():
                        selection="uniform", penalty="l1", loss="log")
     clf.fit(bin_dense, bin_target)
     acc = clf.score(bin_dense, bin_target)
-    assert_almost_equal(acc, 0.995)
+    np.testing.assert_almost_equal(acc, 0.995)
 
 
 def test_fit_linear_binary_l2r():
     clf = CDClassifier(C=1.0, random_state=0, penalty="l2")
     clf.fit(bin_dense, bin_target)
     acc = clf.score(bin_dense, bin_target)
-    assert_almost_equal(acc, 1.0)
+    np.testing.assert_almost_equal(acc, 1.0)
 
 
 def test_fit_linear_binary_l2r_log():
@@ -131,7 +124,7 @@ def test_fit_linear_binary_l2r_log():
                        max_iter=5)
     clf.fit(bin_dense, bin_target)
     acc = clf.score(bin_dense, bin_target)
-    assert_almost_equal(acc, 1.0)
+    np.testing.assert_almost_equal(acc, 1.0)
 
 
 def test_fit_linear_binary_l2r_modified_huber():
@@ -140,14 +133,14 @@ def test_fit_linear_binary_l2r_modified_huber():
     clf.fit(bin_dense, bin_target)
     check_predict_proba(clf, bin_dense)
     acc = clf.score(bin_dense, bin_target)
-    assert_almost_equal(acc, 1.0)
+    np.testing.assert_almost_equal(acc, 1.0)
 
 
 def test_fit_linear_multi_l2r():
     clf = CDClassifier(C=1.0, random_state=0, penalty="l2")
     clf.fit(mult_dense, mult_target)
     acc = clf.score(mult_dense, mult_target)
-    assert_almost_equal(acc, 0.8833, 4)
+    np.testing.assert_almost_equal(acc, 0.8833, 4)
 
 
 def test_warm_start_l2r():
@@ -155,11 +148,11 @@ def test_warm_start_l2r():
 
     clf.C = 0.1
     clf.fit(bin_dense, bin_target)
-    assert_almost_equal(clf.score(bin_dense, bin_target), 1.0)
+    np.testing.assert_almost_equal(clf.score(bin_dense, bin_target), 1.0)
 
     clf.C = 0.2
     clf.fit(bin_dense, bin_target)
-    assert_almost_equal(clf.score(bin_dense, bin_target), 1.0)
+    np.testing.assert_almost_equal(clf.score(bin_dense, bin_target), 1.0)
 
 
 def test_debiasing_l1():
@@ -168,8 +161,8 @@ def test_debiasing_l1():
                            warm_debiasing=warm_debiasing,
                            C=0.05, Cd=1.0, max_iter=10, random_state=0)
         clf.fit(bin_dense, bin_target)
-        assert_equal(clf.n_nonzero(), 22)
-        assert_almost_equal(clf.score(bin_dense, bin_target), 0.955, 3)
+        assert clf.n_nonzero() == 22
+        np.testing.assert_almost_equal(clf.score(bin_dense, bin_target), 0.955, 3)
 
 
 def test_debiasing_l1l2():
@@ -180,8 +173,8 @@ def test_debiasing_l1l2():
                            warm_debiasing=warm_debiasing,
                            max_iter=20, C=0.01, random_state=0)
         clf.fit(mult_csc, mult_target)
-        assert_greater(clf.score(mult_csc, mult_target), 0.75)
-        assert_equal(clf.n_nonzero(percentage=True), 0.08)
+        assert clf.score(mult_csc, mult_target) > 0.75
+        assert clf.n_nonzero(percentage=True) == 0.08
 
 
 def test_debiasing_warm_start():
@@ -189,52 +182,52 @@ def test_debiasing_warm_start():
                        warm_start=True, random_state=0)
     clf.C = 0.5
     clf.fit(bin_dense, bin_target)
-    assert_equal(clf.n_nonzero(), 74)
-    assert_almost_equal(clf.score(bin_dense, bin_target), 1.0)
+    assert clf.n_nonzero() == 74
+    np.testing.assert_almost_equal(clf.score(bin_dense, bin_target), 1.0)
 
     clf.C = 1.0
     clf.fit(bin_dense, bin_target)
     # FIXME: not the same sparsity as without warm start...
-    assert_equal(clf.n_nonzero(), 77)
-    assert_almost_equal(clf.score(bin_dense, bin_target), 1.0)
+    assert clf.n_nonzero() == 77
+    np.testing.assert_almost_equal(clf.score(bin_dense, bin_target), 1.0)
 
 
 def test_empty_model():
     clf = CDClassifier(C=1e-5, penalty="l1")
     clf.fit(bin_dense, bin_target)
-    assert_equal(clf.n_nonzero(), 0)
+    assert clf.n_nonzero() == 0
     acc = clf.score(bin_dense, bin_target)
-    assert_equal(acc, 0.5)
+    assert acc == 0.5
 
     clf = CDClassifier(C=1e-5, penalty="l1", debiasing=True)
     clf.fit(bin_dense, bin_target)
-    assert_equal(clf.n_nonzero(), 0)
+    assert clf.n_nonzero() == 0
     acc = clf.score(bin_dense, bin_target)
-    assert_equal(acc, 0.5)
+    assert acc == 0.5
 
 
 def test_fit_squared_loss():
     clf = CDClassifier(C=1.0, random_state=0, penalty="l2",
                        loss="squared", max_iter=100)
     clf.fit(bin_dense, bin_target)
-    assert_almost_equal(clf.score(bin_dense, bin_target), 0.99)
+    np.testing.assert_almost_equal(clf.score(bin_dense, bin_target), 0.99)
     y = bin_target.copy()
     y[y == 0] = -1
-    assert_array_almost_equal(np.dot(bin_dense, clf.coef_.ravel()) - y,
-                              clf.errors_.ravel())
+    np.testing.assert_array_almost_equal(np.dot(bin_dense, clf.coef_.ravel()) - y,
+                                         clf.errors_.ravel())
 
 
 def test_fit_squared_loss_l1():
     clf = CDClassifier(C=0.5, random_state=0, penalty="l1",
                        loss="squared", max_iter=100, shrinking=False)
     clf.fit(bin_dense, bin_target)
-    assert_almost_equal(clf.score(bin_dense, bin_target), 0.985, 3)
+    np.testing.assert_almost_equal(clf.score(bin_dense, bin_target), 0.985, 3)
     y = bin_target.copy()
     y[y == 0] = -1
-    assert_array_almost_equal(np.dot(bin_dense, clf.coef_.ravel()) - y,
-                              clf.errors_.ravel())
+    np.testing.assert_array_almost_equal(np.dot(bin_dense, clf.coef_.ravel()) - y,
+                                         clf.errors_.ravel())
     n_nz = clf.n_nonzero()
-    assert_equal(n_nz, 89)
+    assert n_nz == 89
 
 
 def test_l1l2_multiclass_log_loss():
@@ -242,24 +235,24 @@ def test_l1l2_multiclass_log_loss():
         clf = CDClassifier(penalty="l1/l2", loss="log", multiclass=True,
                            max_steps=30, max_iter=5, C=1.0, random_state=0)
         clf.fit(data, mult_target)
-        assert_almost_equal(clf.score(data, mult_target), 0.8766, 3)
+        np.testing.assert_almost_equal(clf.score(data, mult_target), 0.8766, 3)
         df = clf.decision_function(data)
         sel = np.array([df[i, int(mult_target[i])] for i in xrange(df.shape[0])])
         df -= sel[:, np.newaxis]
         df = np.exp(df)
-        assert_array_almost_equal(clf.errors_, df.T)
+        np.testing.assert_array_almost_equal(clf.errors_, df.T)
         for i in xrange(data.shape[0]):
-            assert_almost_equal(clf.errors_[mult_target[i], i], 1.0)
+            np.testing.assert_almost_equal(clf.errors_[mult_target[i], i], 1.0)
         nz = np.sum(clf.coef_ != 0)
-        assert_equal(nz, 297)
+        assert nz == 297
 
         clf = CDClassifier(penalty="l1/l2", loss="log", multiclass=True,
                            max_steps=30, max_iter=5, C=0.3, random_state=0)
         clf.fit(data, mult_target)
-        assert_almost_equal(clf.score(data, mult_target), 0.8566, 3)
+        np.testing.assert_almost_equal(clf.score(data, mult_target), 0.8566, 3)
         nz = np.sum(clf.coef_ != 0)
-        assert_equal(nz, 213)
-        assert_true(nz % 3 == 0) # should be a multiple of n_classes
+        assert nz == 213
+        assert nz % 3 == 0  # should be a multiple of n_classes
 
 
 def test_l1l2_multiclass_log_loss_no_linesearch():
@@ -268,9 +261,9 @@ def test_l1l2_multiclass_log_loss_no_linesearch():
                        selection="uniform", max_steps=0,
                        max_iter=30, C=1.0, random_state=0)
     clf.fit(data, mult_target)
-    assert_almost_equal(clf.score(data, mult_target), 0.88, 3)
+    np.testing.assert_almost_equal(clf.score(data, mult_target), 0.88, 3)
     nz = np.sum(clf.coef_ != 0)
-    assert_equal(nz, 297)
+    assert nz == 297
 
 
 def test_l1l2_multiclass_squared_hinge_loss():
@@ -279,24 +272,24 @@ def test_l1l2_multiclass_squared_hinge_loss():
                            multiclass=True,
                            max_iter=20, C=1.0, random_state=0)
         clf.fit(data, mult_target)
-        assert_almost_equal(clf.score(data, mult_target), 0.913, 3)
+        np.testing.assert_almost_equal(clf.score(data, mult_target), 0.913, 3)
         df = clf.decision_function(data)
         n_samples, n_vectors = df.shape
         diff = np.zeros_like(clf.errors_)
         for i in xrange(n_samples):
             for k in xrange(n_vectors):
                 diff[k, i] = 1 - (df[i, mult_target[i]] - df[i, k])
-        assert_array_almost_equal(clf.errors_, diff)
-        assert_equal(np.sum(clf.coef_ != 0), 300)
+        np.testing.assert_array_almost_equal(clf.errors_, diff)
+        assert np.sum(clf.coef_ != 0) == 300
 
         clf = CDClassifier(penalty="l1/l2", loss="squared_hinge",
                            multiclass=True,
                            max_iter=20, C=0.05, random_state=0)
         clf.fit(data, mult_target)
-        assert_almost_equal(clf.score(data, mult_target), 0.83, 3)
+        np.testing.assert_almost_equal(clf.score(data, mult_target), 0.83, 3)
         nz = np.sum(clf.coef_ != 0)
-        assert_equal(nz, 207)
-        assert_true(nz % 3 == 0) # should be a multiple of n_classes
+        assert nz == 207
+        assert nz % 3 == 0  # should be a multiple of n_classes
 
 
 def test_l1l2_multiclass_squared_hinge_loss_no_linesearch():
@@ -305,24 +298,24 @@ def test_l1l2_multiclass_squared_hinge_loss_no_linesearch():
                        multiclass=True, shrinking=False, selection="uniform",
                        max_steps=0, max_iter=200, C=1.0, random_state=0)
     clf.fit(data, mult_target)
-    assert_almost_equal(clf.score(data, mult_target), 0.9166, 3)
+    np.testing.assert_almost_equal(clf.score(data, mult_target), 0.9166, 3)
     df = clf.decision_function(data)
     n_samples, n_vectors = df.shape
     diff = np.zeros_like(clf.errors_)
     for i in xrange(n_samples):
         for k in xrange(n_vectors):
             diff[k, i] = 1 - (df[i, mult_target[i]] - df[i, k])
-    assert_array_almost_equal(clf.errors_, diff)
-    assert_equal(np.sum(clf.coef_ != 0), 300)
+    np.testing.assert_array_almost_equal(clf.errors_, diff)
+    assert np.sum(clf.coef_ != 0) == 300
 
     clf = CDClassifier(penalty="l1/l2", loss="squared_hinge",
                        multiclass=True,
                        max_iter=20, C=0.05, random_state=0)
     clf.fit(data, mult_target)
-    assert_almost_equal(clf.score(data, mult_target), 0.83, 3)
+    np.testing.assert_almost_equal(clf.score(data, mult_target), 0.83, 3)
     nz = np.sum(clf.coef_ != 0)
-    assert_equal(nz, 207)
-    assert_true(nz % 3 == 0) # should be a multiple of n_classes
+    assert nz == 207
+    assert nz % 3 == 0  # should be a multiple of n_classes
 
 
 
@@ -333,18 +326,18 @@ def test_l1l2_multi_task_squared_hinge_loss():
                        max_iter=20, C=5.0, random_state=0)
     clf.fit(mult_dense, mult_target)
     df = clf.decision_function(mult_dense)
-    assert_array_almost_equal(clf.errors_.T, 1 - Y * df)
-    assert_almost_equal(clf.score(mult_dense, mult_target), 0.8633, 3)
+    np.testing.assert_array_almost_equal(clf.errors_.T, 1 - Y * df)
+    np.testing.assert_almost_equal(clf.score(mult_dense, mult_target), 0.8633, 3)
     nz = np.sum(clf.coef_ != 0)
-    assert_equal(nz, 300)
+    assert nz == 300
 
     clf = CDClassifier(penalty="l1/l2", loss="squared_hinge",
                        multiclass=False,
                        max_iter=20, C=0.05, random_state=0)
     clf.fit(mult_dense, mult_target)
-    assert_almost_equal(clf.score(mult_dense, mult_target), 0.8266, 3)
+    np.testing.assert_almost_equal(clf.score(mult_dense, mult_target), 0.8266, 3)
     nz = np.sum(clf.coef_ != 0)
-    assert_equal(nz, 231)
+    assert nz == 231
 
 
 def test_l1l2_multi_task_log_loss():
@@ -353,7 +346,7 @@ def test_l1l2_multi_task_log_loss():
                        max_steps=30,
                        max_iter=20, C=5.0, random_state=0)
     clf.fit(mult_dense, mult_target)
-    assert_almost_equal(clf.score(mult_dense, mult_target), 0.8633, 3)
+    np.testing.assert_almost_equal(clf.score(mult_dense, mult_target), 0.8633, 3)
 
 
 def test_l1l2_multi_task_square_loss():
@@ -361,7 +354,7 @@ def test_l1l2_multi_task_square_loss():
                        multiclass=False,
                        max_iter=20, C=5.0, random_state=0)
     clf.fit(mult_dense, mult_target)
-    assert_almost_equal(clf.score(mult_dense, mult_target), 0.8066, 3)
+    np.testing.assert_almost_equal(clf.score(mult_dense, mult_target), 0.8066, 3)
 
 
 def test_fit_reg_squared_l2():
@@ -370,7 +363,7 @@ def test_fit_reg_squared_l2():
     clf.fit(digit.data, digit.target)
     y_pred = (clf.predict(digit.data) > 0.5).astype(int)
     acc = np.mean(digit.target == y_pred)
-    assert_almost_equal(acc, 1.0, 3)
+    np.testing.assert_almost_equal(acc, 1.0, 3)
 
 
 def test_fit_reg_squared_l1():
@@ -379,7 +372,7 @@ def test_fit_reg_squared_l1():
     clf.fit(digit.data, digit.target)
     y_pred = (clf.predict(digit.data) > 0.5).astype(int)
     acc = np.mean(digit.target == y_pred)
-    assert_almost_equal(acc, 1.0, 3)
+    np.testing.assert_almost_equal(acc, 1.0, 3)
 
 
 def test_fit_reg_squared_multiple_outputs():
@@ -390,8 +383,8 @@ def test_fit_reg_squared_multiple_outputs():
     Y[:, 1] = digit.target
     reg.fit(digit.data, Y)
     y_pred = reg.predict(digit.data)
-    assert_equal(y_pred.shape[0], len(digit.target))
-    assert_equal(y_pred.shape[1], 2)
+    assert y_pred.shape[0] == len(digit.target)
+    assert y_pred.shape[1] == 2
 
 
 def test_fit_reg_squared_multiple_outputs():
@@ -401,23 +394,23 @@ def test_fit_reg_squared_multiple_outputs():
     Y = lb.fit_transform(mult_target)
     reg.fit(mult_dense, Y)
     y_pred = lb.inverse_transform(reg.predict(mult_dense))
-    assert_almost_equal(np.mean(y_pred == mult_target), 0.797, 3)
-    assert_almost_equal(reg.n_nonzero(percentage=True), 0.5)
+    np.testing.assert_almost_equal(np.mean(y_pred == mult_target), 0.797, 3)
+    np.testing.assert_almost_equal(reg.n_nonzero(percentage=True), 0.5)
 
 
 def test_multiclass_error_nongrouplasso():
     for penalty in ['l1', 'l2']:
         clf = CDClassifier(multiclass=True, penalty=penalty)
-        assert_raises(NotImplementedError, clf.fit, mult_dense, mult_target)
+        np.testing.assert_raises(NotImplementedError, clf.fit, mult_dense, mult_target)
 
 
 def test_bin_classes():
     clf = CDClassifier()
     clf.fit(bin_dense, bin_target)
-    assert_equal(list(clf.classes_), [0, 1])
+    assert list(clf.classes_) == [0, 1]
 
 
 def test_multiclass_classes():
     clf = CDClassifier()
     clf.fit(mult_dense, mult_target)
-    assert_equal(list(clf.classes_), [0, 1, 2])
+    assert list(clf.classes_) == [0, 1, 2]

--- a/lightning/impl/tests/test_primal_newton.py
+++ b/lightning/impl/tests/test_primal_newton.py
@@ -1,5 +1,4 @@
-from sklearn.utils.testing import assert_almost_equal
-from sklearn.utils.testing import assert_equal
+import numpy as np
 
 from lightning.impl.datasets.samples_generator import make_classification
 from lightning.impl.primal_newton import KernelSVC
@@ -11,5 +10,5 @@ bin_dense, bin_target = make_classification(n_samples=200, n_features=100,
 def test_kernel_svc():
     clf = KernelSVC(kernel="rbf", gamma=0.1, random_state=0, verbose=0)
     clf.fit(bin_dense, bin_target)
-    assert_almost_equal(clf.score(bin_dense, bin_target), 1.0)
-    assert_equal(list(clf.classes_), [0, 1])
+    np.testing.assert_almost_equal(clf.score(bin_dense, bin_target), 1.0)
+    assert list(clf.classes_) == [0, 1]

--- a/lightning/impl/tests/test_prox.py
+++ b/lightning/impl/tests/test_prox.py
@@ -1,5 +1,4 @@
 import numpy as np
-from nose.tools import assert_equal
 
 from lightning.impl import prox_fast
 
@@ -27,4 +26,4 @@ def test_tv1d_dtype():
     for dtype in (np.float32, np.float64):
         y = x.astype(dtype, copy=True)
         prox_fast.prox_tv1d(y, 0.01)
-        assert_equal(y.dtype, dtype)
+        assert y.dtype == dtype

--- a/lightning/impl/tests/test_sag.py
+++ b/lightning/impl/tests/test_sag.py
@@ -1,12 +1,8 @@
 import numpy as np
 from scipy import sparse
 
-from numpy.testing import assert_array_equal
-
 from sklearn.datasets import load_iris, make_classification
 from sklearn.preprocessing import LabelBinarizer
-from sklearn.utils.testing import assert_true
-from sklearn.utils.testing import assert_equal, assert_almost_equal
 
 from lightning.impl.base import BaseClassifier
 from lightning.impl.dataset_fast import get_dataset
@@ -197,12 +193,12 @@ def test_l1_prox():
     x = np.ones(5)
     for l1 in [0.1, 0.5, .99, 1.]:
         penalty = L1Penalty(l1=l1)
-        assert_array_equal(penalty.projection(x, stepsize=1.), x - l1)
-        assert_array_equal(penalty.projection(-x, stepsize=1.), -x + l1)
+        np.testing.assert_array_equal(penalty.projection(x, stepsize=1.), x - l1)
+        np.testing.assert_array_equal(penalty.projection(-x, stepsize=1.), -x + l1)
 
     penalty = L1Penalty(l1=2.)
-    assert_array_equal(penalty.projection(x, stepsize=1.), 0)
-    assert_array_equal(penalty.projection(-x, stepsize=1.), 0)
+    np.testing.assert_array_equal(penalty.projection(x, stepsize=1.), 0)
+    np.testing.assert_array_equal(penalty.projection(-x, stepsize=1.), 0)
 
 
 def test_sag():
@@ -213,8 +209,8 @@ def test_sag():
             ):
         clf.fit(X_bin, y_bin)
         assert not hasattr(clf, 'predict_proba')
-        assert_equal(clf.score(X_bin, y_bin), 1.0)
-        assert_equal(list(clf.classes_), [-1, 1])
+        assert clf.score(X_bin, y_bin) == 1.0
+        assert list(clf.classes_) == [-1, 1]
 
 
 def test_sag_dataset():
@@ -224,7 +220,7 @@ def test_sag_dataset():
         clf2 = SAG_(eta=1e-3, max_iter=20, verbose=0, random_state=0)
         clf1.fit(get_dataset(X_bin, order='C'), y_bin)
         clf2.fit(X_bin, y_bin)
-        assert_almost_equal(clf1.coef_, clf2.coef_)
+        np.testing.assert_almost_equal(clf1.coef_, clf2.coef_)
 
 
 def test_sag_score():
@@ -237,7 +233,7 @@ def test_sag_score():
 
     pysag.fit(X, y)
     sag.fit(X, y)
-    assert_equal(pysag.score(X, y), sag.score(X, y))
+    assert pysag.score(X, y) == sag.score(X, y)
 
 
 def test_sag_proba():
@@ -254,7 +250,7 @@ def test_sag_multiclass_classes():
                                n_informative=4)
     sag = SAGClassifier()
     sag.fit(X, y)
-    assert_equal(list(sag.classes_), [0, 1, 2])
+    assert list(sag.classes_) == [0, 1, 2]
 
 
 def test_no_reg_sag():
@@ -287,7 +283,7 @@ def test_saga_score():
 
     pysaga.fit(X, y)
     saga.fit(X, y)
-    assert_equal(pysaga.score(X, y), saga.score(X, y))
+    assert pysaga.score(X, y) == saga.score(X, y)
 
 
 def test_enet_regularized_saga():
@@ -374,7 +370,7 @@ def test_sag_callback():
         clf.fit(X_bin, y_bin)
         # its not a descent method, just check that most of
         # updates are decreasing the objective function
-        assert_true(np.mean(np.diff(cb.obj) <= 0) > 0.9)
+        assert np.mean(np.diff(cb.obj) <= 0) > 0.9
 
 
 def test_auto_stepsize():
@@ -385,7 +381,7 @@ def test_auto_stepsize():
         PySAGClassifier(loss='log', max_iter=20, random_state=0)
             ):
         clf.fit(X_bin, y_bin)
-        assert_equal(clf.score(X_bin, y_bin), 1.0)
+        assert clf.score(X_bin, y_bin) == 1.0
 
 
 def test_sag_regression():
@@ -395,7 +391,7 @@ def test_sag_regression():
             ):
         reg.fit(X_bin, y_bin)
         y_pred = np.sign(reg.predict(X_bin))
-        assert_equal(np.mean(y_bin == y_pred), 1.0)
+        assert np.mean(y_bin == y_pred) == 1.0
 
 
 def test_sag_sparse():
@@ -411,7 +407,7 @@ def test_sag_sparse():
         clf_dense = SAGClassifier(eta=1., max_iter=1, random_state=0,
                                   alpha=alpha)
         clf_dense.fit(X.toarray(), y)
-        assert_equal(clf_sparse.score(X, y), clf_dense.score(X, y))
+        assert clf_sparse.score(X, y) == clf_dense.score(X, y)
 
         clf_sparse = SAGAClassifier(eta=1.,
                                     max_iter=1, random_state=0, alpha=alpha)
@@ -419,7 +415,7 @@ def test_sag_sparse():
         clf_dense = SAGAClassifier(eta=1.,
                                    max_iter=1, random_state=0, alpha=alpha)
         clf_dense.fit(X.toarray(), y)
-        assert_equal(clf_sparse.score(X, y), clf_dense.score(X, y))
+        assert clf_sparse.score(X, y) == clf_dense.score(X, y)
 
 
 def test_sag_sample_weights():
@@ -468,7 +464,7 @@ def test_sag_adaptive():
         clf = SAGClassifier(
             eta='auto', random_state=0, alpha=alpha)
         clf.fit(X, y)
-        assert_almost_equal(clf_adaptive.score(X, y), clf.score(X, y), 1)
+        np.testing.assert_almost_equal(clf_adaptive.score(X, y), clf.score(X, y), 1)
 
         clf_adaptive = SAGAClassifier(
             eta='line-search', loss='log', random_state=0, alpha=alpha, max_iter=20)
@@ -477,7 +473,7 @@ def test_sag_adaptive():
         clf = SAGAClassifier(
             eta='auto', loss='log', random_state=0, alpha=alpha, max_iter=20)
         clf.fit(X, y)
-        assert_almost_equal(clf_adaptive.score(X, y), clf.score(X, y), 1)
+        np.testing.assert_almost_equal(clf_adaptive.score(X, y), clf.score(X, y), 1)
 
 if __name__ == '__main__':
     import nose

--- a/lightning/impl/tests/test_sdca.py
+++ b/lightning/impl/tests/test_sdca.py
@@ -1,8 +1,6 @@
 import numpy as np
 
 from sklearn.datasets import load_iris
-from sklearn.utils.testing import assert_equal
-from sklearn.utils.testing import assert_almost_equal
 
 from lightning.classification import SDCAClassifier
 from lightning.regression import SDCARegressor
@@ -20,35 +18,35 @@ def test_sdca_hinge():
     clf = SDCAClassifier(loss="hinge", random_state=0)
     clf.fit(X_bin, y_bin)
     assert not hasattr(clf, 'predict_proba')
-    assert_equal(clf.score(X_bin, y_bin), 1.0)
+    assert clf.score(X_bin, y_bin) == 1.0
 
 
 def test_sdca_hinge_multiclass():
     clf = SDCAClassifier(alpha=1e-2, max_iter=100, loss="hinge",
                               random_state=0)
     clf.fit(X, y)
-    assert_almost_equal(clf.score(X, y), 0.947, 3)
+    np.testing.assert_almost_equal(clf.score(X, y), 0.947, 3)
 
 
 def test_sdca_squared():
     clf = SDCAClassifier(loss="squared", random_state=0)
     clf.fit(X_bin, y_bin)
     assert not hasattr(clf, 'predict_proba')
-    assert_equal(clf.score(X_bin, y_bin), 1.0)
+    assert clf.score(X_bin, y_bin) == 1.0
 
 
 def test_sdca_absolute():
     clf = SDCAClassifier(loss="absolute", random_state=0)
     clf.fit(X_bin, y_bin)
     assert not hasattr(clf, 'predict_proba')
-    assert_equal(clf.score(X_bin, y_bin), 1.0)
+    assert clf.score(X_bin, y_bin) == 1.0
 
 
 def test_sdca_hinge_elastic():
     clf = SDCAClassifier(alpha=0.5, l1_ratio=0.85, loss="hinge",
                               random_state=0)
     clf.fit(X_bin, y_bin)
-    assert_equal(clf.score(X_bin, y_bin), 1.0)
+    assert clf.score(X_bin, y_bin) == 1.0
 
 
 def test_sdca_smooth_hinge_elastic():
@@ -56,42 +54,42 @@ def test_sdca_smooth_hinge_elastic():
                               random_state=0)
     clf.fit(X_bin, y_bin)
     assert not hasattr(clf, 'predict_proba')
-    assert_equal(clf.score(X_bin, y_bin), 1.0)
+    assert clf.score(X_bin, y_bin) == 1.0
 
 
 def test_sdca_squared_hinge_elastic():
     clf = SDCAClassifier(alpha=0.5, l1_ratio=0.85, loss="squared_hinge",
                               random_state=0)
     clf.fit(X_bin, y_bin)
-    assert_equal(clf.score(X_bin, y_bin), 1.0)
+    assert clf.score(X_bin, y_bin) == 1.0
 
 
 def test_sdca_hinge_l1_only():
     clf = SDCAClassifier(alpha=0.5, l1_ratio=1.0, loss="hinge", tol=1e-2,
                               max_iter=200, random_state=0)
     clf.fit(X_bin, y_bin)
-    assert_equal(clf.score(X_bin, y_bin), 1.0)
+    assert clf.score(X_bin, y_bin) == 1.0
 
 
 def test_sdca_smooth_hinge_l1_only():
     clf = SDCAClassifier(alpha=0.5, l1_ratio=1.0, loss="smooth_hinge",
                               tol=1e-2, max_iter=200, random_state=0)
     clf.fit(X_bin, y_bin)
-    assert_equal(clf.score(X_bin, y_bin), 1.0)
+    assert clf.score(X_bin, y_bin) == 1.0
 
 
 def test_sdca_squared_l1_only():
     clf = SDCAClassifier(alpha=0.5, l1_ratio=1.0, loss="squared", tol=1e-2,
                               max_iter=100, random_state=0)
     clf.fit(X_bin, y_bin)
-    assert_equal(clf.score(X_bin, y_bin), 1.0)
+    assert clf.score(X_bin, y_bin) == 1.0
 
 
 def test_sdca_absolute_l1_only():
     clf = SDCAClassifier(alpha=0.5, l1_ratio=1.0, loss="absolute",
                               tol=1e-2, max_iter=200, random_state=0)
     clf.fit(X_bin, y_bin)
-    assert_equal(clf.score(X_bin, y_bin), 1.0)
+    assert clf.score(X_bin, y_bin) == 1.0
 
 
 def test_sdca_callback():
@@ -110,20 +108,20 @@ def test_sdca_callback():
     clf = SDCAClassifier(alpha=0.5, l1_ratio=0.85, loss="hinge",
                               callback=cb, random_state=0)
     clf.fit(X_bin, y_bin)
-    assert_equal(cb.acc[0], 0.5)
-    assert_equal(cb.acc[-1], 1.0)
+    assert cb.acc[0] == 0.5
+    assert cb.acc[-1] == 1.0
 
 
 def test_bin_classes():
     clf = SDCAClassifier()
     clf.fit(X_bin, y_bin)
-    assert_equal(list(clf.classes_), [-1, 1])
+    assert list(clf.classes_) == [-1, 1]
 
 
 def test_multiclass_classes():
     clf = SDCAClassifier()
     clf.fit(X, y)
-    assert_equal(list(clf.classes_), [0, 1, 2])
+    assert list(clf.classes_) == [0, 1, 2]
 
 
 def test_sdca_regression():
@@ -131,5 +129,5 @@ def test_sdca_regression():
         reg = SDCARegressor(loss=loss)
         reg.fit(X_bin, y_bin)
         y_pred = np.sign(reg.predict(X_bin))
-        assert_equal(np.mean(y_bin == y_pred), 1.0)
+        assert np.mean(y_bin == y_pred) == 1.0
 

--- a/lightning/impl/tests/test_sgd.py
+++ b/lightning/impl/tests/test_sgd.py
@@ -1,11 +1,6 @@
 import numpy as np
 import scipy.sparse as sp
 
-from sklearn.utils.testing import assert_almost_equal
-from sklearn.utils.testing import assert_false
-from sklearn.utils.testing import assert_greater
-from sklearn.utils.testing import assert_equal
-
 from sklearn.datasets.samples_generator import make_regression
 
 from lightning.impl.datasets.samples_generator import make_classification
@@ -46,8 +41,8 @@ def test_binary_linear_sgd():
                                   fit_intercept=True, learning_rate="constant"),
                     ):
             clf.fit(data, bin_target)
-            assert_greater(clf.score(data, bin_target), 0.934)
-            assert_equal(list(clf.classes_), [0, 1])
+            assert clf.score(data, bin_target) > 0.934
+            assert list(clf.classes_) == [0, 1]
             if clf.loss in ('log', 'modified_huber'):
                 check_predict_proba(clf, data)
             else:
@@ -57,8 +52,8 @@ def test_binary_linear_sgd():
 def test_multiclass_sgd():
     clf = SGDClassifier(random_state=0)
     clf.fit(mult_dense, mult_target)
-    assert_greater(clf.score(mult_dense, mult_target), 0.80)
-    assert_equal(list(clf.classes_), [0, 1, 2])
+    assert clf.score(mult_dense, mult_target) > 0.80
+    assert list(clf.classes_) == [0, 1, 2]
 
 
 def test_multiclass_hinge_sgd():
@@ -67,7 +62,7 @@ def test_multiclass_hinge_sgd():
             clf = SGDClassifier(loss="hinge", multiclass=True,
                                 fit_intercept=fit_intercept, random_state=0)
             clf.fit(data, mult_target)
-            assert_greater(clf.score(data, mult_target), 0.78)
+            assert clf.score(data, mult_target) > 0.78
 
 
 def test_multiclass_hinge_sgd_l1l2():
@@ -75,7 +70,7 @@ def test_multiclass_hinge_sgd_l1l2():
         clf = SGDClassifier(loss="hinge", penalty="l1/l2",
                             multiclass=True, random_state=0)
         clf.fit(data, mult_target)
-        assert_greater(clf.score(data, mult_target), 0.75)
+        assert clf.score(data, mult_target) > 0.75
 
 
 def test_multiclass_squared_hinge_sgd():
@@ -85,7 +80,7 @@ def test_multiclass_squared_hinge_sgd():
                                 learning_rate="constant", eta0=1e-3,
                                 fit_intercept=fit_intercept, random_state=0)
             clf.fit(data, mult_target)
-            assert_greater(clf.score(data, mult_target), 0.78)
+            assert clf.score(data, mult_target) > 0.78
 
 
 def test_multiclass_log_sgd():
@@ -95,7 +90,7 @@ def test_multiclass_log_sgd():
                                 fit_intercept=fit_intercept,
                                 random_state=0)
             clf.fit(data, mult_target)
-            assert_greater(clf.score(data, mult_target), 0.78)
+            assert clf.score(data, mult_target) > 0.78
 
 
 def test_regression_squared_loss():
@@ -106,7 +101,7 @@ def test_regression_squared_loss():
 
     reg.fit(X, y)
     pred = reg.predict(X)
-    assert_almost_equal(np.mean((pred - y) ** 2), 4.749, 3)
+    np.testing.assert_almost_equal(np.mean((pred - y) ** 2), 4.749, 3)
 
 
 def test_regression_squared_loss_nn_l1():
@@ -119,8 +114,8 @@ def test_regression_squared_loss_nn_l1():
 
         reg.fit(X, y)
         pred = reg.predict(X)
-        assert_almost_equal(np.mean((pred - y) ** 2), 0.016, 3)
-        assert_false((reg.coef_ < 0).any())
+        np.testing.assert_almost_equal(np.mean((pred - y) ** 2), 0.016, 3)
+        assert (reg.coef_ >= 0).all()
 
 
 def test_regression_squared_loss_nn_l2():
@@ -132,9 +127,9 @@ def test_regression_squared_loss_nn_l2():
 
     reg.fit(X, y)
     pred = reg.predict(X)
-    assert_almost_equal(np.mean((pred - y) ** 2), 0.016, 3)
-    assert_almost_equal(reg.coef_.sum(), 2.131, 3)
-    assert_false((reg.coef_ < 0).any())
+    np.testing.assert_almost_equal(np.mean((pred - y) ** 2), 0.016, 3)
+    np.testing.assert_almost_equal(reg.coef_.sum(), 2.131, 3)
+    assert (reg.coef_ >= 0).all()
 
 
 def test_regression_squared_loss_multiple_output():
@@ -147,5 +142,5 @@ def test_regression_squared_loss_multiple_output():
     Y[:, 1] = y
     reg.fit(X, Y)
     pred = reg.predict(X)
-    assert_almost_equal(np.mean((pred - Y) ** 2), 4.397, 3)
+    np.testing.assert_almost_equal(np.mean((pred - Y) ** 2), 4.397, 3)
 

--- a/lightning/impl/tests/test_svrg.py
+++ b/lightning/impl/tests/test_svrg.py
@@ -2,8 +2,6 @@ import numpy as np
 
 from sklearn.datasets import load_iris
 from sklearn.base import BaseEstimator, ClassifierMixin
-from sklearn.utils.testing import assert_true
-from sklearn.utils.testing import assert_equal
 
 from lightning.classification import SVRGClassifier
 from lightning.regression import SVRGRegressor
@@ -20,7 +18,7 @@ def test_svrg():
     clf = SVRGClassifier(eta=1e-3, max_iter=20, random_state=0, verbose=0)
     clf.fit(X_bin, y_bin)
     assert not hasattr(clf, 'predict_proba')
-    assert_equal(clf.score(X_bin, y_bin), 1.0)
+    assert clf.score(X_bin, y_bin) == 1.0
 
 
 def test_svrg_callback():
@@ -43,23 +41,23 @@ def test_svrg_callback():
     clf = SVRGClassifier(loss="squared_hinge", eta=1e-3, max_iter=20,
                          random_state=0, callback=cb)
     clf.fit(X_bin, y_bin)
-    assert_true(np.all(np.diff(cb.obj) <= 0))
+    assert np.all(np.diff(cb.obj) <= 0)
 
 
 def test_svrg_regression():
     reg = SVRGRegressor(eta=1e-3)
     reg.fit(X_bin, y_bin)
     y_pred = np.sign(reg.predict(X_bin))
-    assert_equal(np.mean(y_bin == y_pred), 1.0)
+    assert np.mean(y_bin == y_pred) == 1.0
 
 
 def test_bin_classes():
     clf = SVRGClassifier()
     clf.fit(X_bin, y_bin)
-    assert_equal(list(clf.classes_), [-1, 1])
+    assert list(clf.classes_) == [-1, 1]
 
 
 def test_multiclass_classes():
     clf = SVRGClassifier()
     clf.fit(X, y)
-    assert_equal(list(clf.classes_), [0, 1, 2])
+    assert list(clf.classes_) == [0, 1, 2]

--- a/lightning/impl/tests/utils.py
+++ b/lightning/impl/tests/utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from sklearn.utils.testing import assert_array_equal, assert_equal
+import numpy as np
 
 
 def check_predict_proba(clf, X):
@@ -10,11 +10,11 @@ def check_predict_proba(clf, X):
 
     # check that predict_proba result agree with y_true
     y_proba = clf.predict_proba(X)
-    assert_equal(y_proba.shape, (n_samples, 2))
+    assert y_proba.shape == (n_samples, 2)
     y_proba_best = (y_proba.argmax(axis=1) == 1)
-    assert_array_equal(y_proba_best, y_pred)
+    np.testing.assert_array_equal(y_proba_best, y_pred)
 
     # check that y_proba looks like probability
     assert not (y_proba > 1).any()
     assert not (y_proba < 0).any()
-    assert_array_equal(y_proba.sum(axis=1), 1.0)
+    np.testing.assert_array_equal(y_proba.sum(axis=1), 1.0)


### PR DESCRIPTION
Fixed #156.

Use normal `assert`s and ones from `numpy.testing` module where normal ones cannot be used (approx, arrays, raises).