### PR TITLE
Fix compatibility with upcoming scikit-learn release and remove unused imports

### DIFF
--- a/lightning/impl/adagrad.py
+++ b/lightning/impl/adagrad.py
@@ -4,7 +4,6 @@
 import numpy as np
 
 from sklearn.utils import check_random_state
-from sklearn.preprocessing import LabelBinarizer
 from six.moves import xrange
 
 from .base import BaseClassifier, BaseRegressor

--- a/lightning/impl/datasets/samples_generator.py
+++ b/lightning/impl/datasets/samples_generator.py
@@ -1,3 +1,5 @@
+from itertools import product
+
 import numpy as np
 import scipy.sparse as sp
 from six.moves import xrange
@@ -195,9 +197,6 @@ def make_classification(n_samples=100, n_features=20, n_informative=2,
     .. [1] I. Guyon, "Design of experiments for the NIPS 2003 variable
            selection benchmark", 2003.
     """
-    from itertools import product
-    from sklearn.utils import shuffle as util_shuffle
-
     generator = check_random_state(random_state)
 
     # Count features, clusters and samples
@@ -308,7 +307,7 @@ def make_classification(n_samples=100, n_features=20, n_informative=2,
 
     # Randomly permute samples and features
     if shuffle:
-        X, y = util_shuffle(X, y, random_state=generator)
+        X, y = shuffle_func(X, y, random_state=generator)
 
         indices = np.arange(n_features)
         generator.shuffle(indices)

--- a/lightning/impl/dual_cd.py
+++ b/lightning/impl/dual_cd.py
@@ -12,7 +12,6 @@ This module provides coordinate descent solvers for support vector machines
 
 import numpy as np
 
-from sklearn.preprocessing import LabelBinarizer
 from sklearn.preprocessing import add_dummy_feature
 from six.moves import xrange
 

--- a/lightning/impl/sdca.py
+++ b/lightning/impl/sdca.py
@@ -4,7 +4,6 @@
 import numpy as np
 
 from sklearn.utils import check_random_state
-from sklearn.preprocessing import LabelBinarizer
 from six.moves import xrange
 
 from .base import BaseClassifier, BaseRegressor

--- a/lightning/impl/svrg.py
+++ b/lightning/impl/svrg.py
@@ -3,7 +3,6 @@
 
 import numpy as np
 
-from sklearn.preprocessing import LabelBinarizer
 from six.moves import xrange
 
 from .base import BaseClassifier, BaseRegressor

--- a/lightning/impl/tests/test_fista.py
+++ b/lightning/impl/tests/test_fista.py
@@ -20,7 +20,7 @@ mult_dense, mult_target = make_classification(n_samples=300, n_features=100,
                                               n_classes=3, random_state=0)
 bin_csr = sp.csr_matrix(bin_dense)
 mult_csr = sp.csr_matrix(mult_dense)
-digit = load_digits(2)
+digit = load_digits(n_class=2)
 
 
 def test_fista_multiclass_l1l2():

--- a/lightning/impl/tests/test_primal_cd.py
+++ b/lightning/impl/tests/test_primal_cd.py
@@ -2,7 +2,6 @@ import numpy as np
 import scipy.sparse as sp
 
 from sklearn.datasets import load_digits
-from sklearn.metrics.pairwise import pairwise_kernels
 from sklearn.preprocessing import LabelBinarizer
 from six.moves import xrange
 
@@ -20,7 +19,7 @@ mult_dense, mult_target = make_classification(n_samples=300, n_features=100,
                                               n_classes=3, random_state=0)
 mult_csc = sp.csc_matrix(mult_dense)
 
-digit = load_digits(2)
+digit = load_digits(n_class=2)
 
 
 def test_fit_linear_binary_l1r():

--- a/lightning/impl/tests/test_sag.py
+++ b/lightning/impl/tests/test_sag.py
@@ -2,7 +2,6 @@ import numpy as np
 from scipy import sparse
 
 from sklearn.datasets import load_iris, make_classification
-from sklearn.preprocessing import LabelBinarizer
 
 from lightning.impl.base import BaseClassifier
 from lightning.impl.dataset_fast import get_dataset
@@ -224,7 +223,7 @@ def test_sag_dataset():
 
 
 def test_sag_score():
-    X, y = make_classification(1000, random_state=0)
+    X, y = make_classification(n_samples=1000, random_state=0)
 
     pysag = PySAGClassifier(eta=1e-3, alpha=0.0, beta=0.0, max_iter=10,
                             random_state=0)
@@ -238,7 +237,7 @@ def test_sag_score():
 
 def test_sag_proba():
     n_samples = 10
-    X, y = make_classification(n_samples, random_state=0)
+    X, y = make_classification(n_samples=n_samples, random_state=0)
     sag = SAGClassifier(eta=1e-3, alpha=0.0, beta=0.0, max_iter=10,
                         loss='log', random_state=0)
     sag.fit(X, y)
@@ -274,7 +273,7 @@ def test_l2_regularized_sag():
 
 
 def test_saga_score():
-    X, y = make_classification(1000, random_state=0)
+    X, y = make_classification(n_samples=1000, random_state=0)
 
     pysaga = PySAGAClassifier(eta=1e-3, alpha=0.0, beta=0.0, max_iter=1,
                               penalty=None, random_state=0)

--- a/lightning/impl/tests/test_svrg.py
+++ b/lightning/impl/tests/test_svrg.py
@@ -1,7 +1,6 @@
 import numpy as np
 
 from sklearn.datasets import load_iris
-from sklearn.base import BaseEstimator, ClassifierMixin
 
 from lightning.classification import SVRGClassifier
 from lightning.regression import SVRGRegressor


### PR DESCRIPTION
Fix
```
/home/travis/miniconda/envs/test-environment/lib/python3.6/site-packages/sklearn/utils/validation.py:72: FutureWarning: Pass n_class=2 as keyword args. From version 1.0 (renaming of 0.25) passing these as positional arguments will result in an error
  "will result in an error", FutureWarning)
```