### PR TITLE
Fix numpy deprecation warnings

### DIFF
--- a/doc/sphinxext/gen_rst.py
+++ b/doc/sphinxext/gen_rst.py
@@ -558,7 +558,7 @@ def line_count_sort(file_list, target_dir):
         unsorted[count][1] = total_lines - docstr_lines
         unsorted[count][0] = exmpl
     index = np.lexsort((unsorted[:, 0].astype(np.str),
-                        unsorted[:, 1].astype(np.float)))
+                        unsorted[:, 1].astype(float)))
     if not len(unsorted):
         return []
     return np.array(unsorted[index][:, 0]).tolist()

--- a/examples/plot_1d_total_variation.py
+++ b/examples/plot_1d_total_variation.py
@@ -31,7 +31,7 @@ n_features = ground_truth.size
 np.random.seed(0)  # for reproducibility
 X = np.random.rand(n_samples, n_features)
 # generate y as a linear model, y = sign(X w + noise)
-y = np.sign(X.dot(ground_truth) + 0.5 * np.random.randn(n_samples)).astype(np.int)
+y = np.sign(X.dot(ground_truth) + 0.5 * np.random.randn(n_samples)).astype(int)
 
 
 for penalty in ('l1', 'tv1d'):

--- a/lightning/impl/datasets/samples_generator.py
+++ b/lightning/impl/datasets/samples_generator.py
@@ -233,7 +233,7 @@ def make_classification(n_samples=100, n_features=20, n_informative=2,
 
     # Intialize X and y
     X = np.zeros((n_samples, n_features))
-    y = np.zeros(n_samples, dtype=np.int)
+    y = np.zeros(n_samples, dtype=int)
 
     # Build the polytope
     C = np.array(list(product([-class_sep, class_sep], repeat=n_informative)))

--- a/lightning/impl/tests/test_sag.py
+++ b/lightning/impl/tests/test_sag.py
@@ -441,7 +441,7 @@ def test_sag_sample_weights():
     # resulting coefficients by adding noise to original samples
     X2 = np.concatenate((X, np.random.randn(*X.shape)), axis=0)   # augment with noise
     y2 = np.concatenate((y, y), axis=0)
-    sample_weights = np.ones(y2.size, dtype=np.float)
+    sample_weights = np.ones(y2.size, dtype=float)
     sample_weights[X.shape[0]:] = 0.
 
     clf1 = SAGARegressor(loss='squared', alpha=alpha,  max_iter=100, random_state=0, tol=1e-24)


### PR DESCRIPTION
Fix
```
  /home/travis/build/scikit-learn-contrib/lightning/lightning/impl/datasets/samples_generator.py:236: DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    y = np.zeros(n_samples, dtype=np.int)
```
and
```
impl/tests/test_sag.py::test_sag_sample_weights
  /home/travis/build/scikit-learn-contrib/lightning/lightning/impl/tests/test_sag.py:444: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    sample_weights = np.ones(y2.size, dtype=np.float)
```