### PR TITLE
use raw strings in docstrings for __init__

### DIFF
--- a/lightning/impl/adagrad.py
+++ b/lightning/impl/adagrad.py
@@ -48,7 +48,7 @@ class _BaseAdagrad(object):
 
 
 class AdaGradClassifier(BaseClassifier, _BaseAdagrad):
-    """
+    r"""
     Estimator for learning linear classifiers by AdaGrad.
 
     Solves the following objective:
@@ -92,7 +92,7 @@ class AdaGradClassifier(BaseClassifier, _BaseAdagrad):
 
 
 class AdaGradRegressor(BaseRegressor, _BaseAdagrad):
-    """
+    r"""
     Estimator for learning linear regressors by AdaGrad.
 
     Solves the following objective:

--- a/lightning/impl/dual_cd.py
+++ b/lightning/impl/dual_cd.py
@@ -23,7 +23,7 @@ from .dual_cd_fast import _dual_cd_svr
 
 
 class LinearSVC(BaseClassifier):
-    """Estimator for learning linear support vector machine by coordinate
+    r"""Estimator for learning linear support vector machine by coordinate
     descent in the dual.
 
     Parameters
@@ -152,7 +152,7 @@ class LinearSVC(BaseClassifier):
 
 
 class LinearSVR(BaseRegressor):
-    """Estimator for learning a linear support vector regressor by coordinate
+    r"""Estimator for learning a linear support vector regressor by coordinate
     descent in the dual.
 
     Parameters

--- a/lightning/impl/fista.py
+++ b/lightning/impl/fista.py
@@ -131,7 +131,7 @@ class _BaseFista(object):
 
 
 class FistaClassifier(BaseClassifier, _BaseFista):
-    """Estimator for learning linear classifiers by FISTA.
+    r"""Estimator for learning linear classifiers by FISTA.
 
     The objective functions considered take the form
 
@@ -227,7 +227,7 @@ class FistaClassifier(BaseClassifier, _BaseFista):
 
 
 class FistaRegressor(BaseRegressor, _BaseFista):
-    """Estimator for learning linear classifiers by FISTA.
+    r"""Estimator for learning linear classifiers by FISTA.
 
     The objective functions considered take the form
 

--- a/lightning/impl/prank.py
+++ b/lightning/impl/prank.py
@@ -26,7 +26,7 @@ class _BasePRank(BaseEstimator):
 
 
 class PRank(_BasePRank):
-    """Online algorithm for learning an ordinal regression model.
+    r"""Online algorithm for learning an ordinal regression model.
 
     Parameters
     ----------
@@ -104,7 +104,7 @@ class PRank(_BasePRank):
 
 
 class KernelPRank(_BasePRank):
-    """Kernelized online algorithm for learning an ordinal regression model.
+    r"""Kernelized online algorithm for learning an ordinal regression model.
 
     Parameters
     ----------

--- a/lightning/impl/primal_cd.py
+++ b/lightning/impl/primal_cd.py
@@ -72,7 +72,7 @@ class _BaseCD(object):
 
 
 class CDClassifier(_BaseCD, BaseClassifier):
-    """Estimator for learning linear classifiers by (block) coordinate descent.
+    r"""Estimator for learning linear classifiers by (block) coordinate descent.
 
     The objective functions considered take the form
 
@@ -355,7 +355,7 @@ class CDClassifier(_BaseCD, BaseClassifier):
 
 
 class CDRegressor(_BaseCD, BaseRegressor):
-    """Estimator for learning linear regressors by (block) coordinate descent.
+    r"""Estimator for learning linear regressors by (block) coordinate descent.
 
     The objective functions considered take the form
 

--- a/lightning/impl/primal_newton.py
+++ b/lightning/impl/primal_newton.py
@@ -24,7 +24,7 @@ from .base import BaseClassifier
 
 
 class KernelSVC(BaseClassifier):
-    """Estimator for learning kernel SVMs by Newton's method.
+    r"""Estimator for learning kernel SVMs by Newton's method.
 
     Parameters
     ----------

--- a/lightning/impl/sag.py
+++ b/lightning/impl/sag.py
@@ -89,7 +89,7 @@ class _BaseSAG(object):
 
 
 class SAGClassifier(BaseClassifier, _BaseSAG):
-    """
+    r"""
     Estimator for learning linear classifiers by SAG.
 
     Solves the following objective:
@@ -166,7 +166,7 @@ class SAGClassifier(BaseClassifier, _BaseSAG):
 
 
 class SAGAClassifier(SAGClassifier):
-    """
+    r"""
     Estimator for learning linear classifiers by SAGA.
 
     Solves the following objective:
@@ -219,7 +219,7 @@ class SAGAClassifier(SAGClassifier):
 
 
 class SAGRegressor(BaseRegressor, _BaseSAG):
-    """
+    r"""
     Estimator for learning linear regressors by SAG.
 
     Solves the following objective:
@@ -293,7 +293,7 @@ class SAGRegressor(BaseRegressor, _BaseSAG):
 
 
 class SAGARegressor(SAGRegressor):
-    """
+    r"""
     Estimator for learning linear regressors by SAG.
 
     Solves the following objective:

--- a/lightning/impl/sdca.py
+++ b/lightning/impl/sdca.py
@@ -72,7 +72,7 @@ class _BaseSDCA(object):
 
 
 class SDCAClassifier(BaseClassifier, _BaseSDCA):
-    """
+    r"""
     Estimator for learning linear classifiers by (proximal) SDCA.
 
     Solves the following objective:
@@ -137,7 +137,7 @@ class SDCAClassifier(BaseClassifier, _BaseSDCA):
 
 
 class SDCARegressor(BaseRegressor, _BaseSDCA):
-    """
+    r"""
     Estimator for learning linear regressors by (proximal) SDCA.
 
     Solves the following objective:

--- a/lightning/impl/sgd.py
+++ b/lightning/impl/sgd.py
@@ -58,7 +58,7 @@ class _BaseSGD(object):
 
 
 class SGDClassifier(BaseClassifier, _BaseSGD):
-    """Estimator for learning linear classifiers by SGD.
+    r"""Estimator for learning linear classifiers by SGD.
 
     Parameters
     ----------
@@ -241,7 +241,7 @@ class SGDClassifier(BaseClassifier, _BaseSGD):
 
 
 class SGDRegressor(BaseRegressor, _BaseSGD):
-    """Estimator for learning linear regressors by SGD.
+    r"""Estimator for learning linear regressors by SGD.
 
     Parameters
     ----------

--- a/lightning/impl/svrg.py
+++ b/lightning/impl/svrg.py
@@ -47,7 +47,7 @@ class _BaseSVRG(object):
 
 
 class SVRGClassifier(BaseClassifier, _BaseSVRG):
-    """
+    r"""
     Estimator for learning linear classifiers by SVRG.
 
     Solves the following objective:
@@ -88,7 +88,7 @@ class SVRGClassifier(BaseClassifier, _BaseSVRG):
 
 
 class SVRGRegressor(BaseRegressor, _BaseSVRG):
-    """
+    r"""
     Estimator for learning linear regressors by SVRG.
 
     Solves the following objective:


### PR DESCRIPTION
There are a lot of LaTeX formulas in doctrings for `__init__()` methods which cause warnings like the following one:
```
lightning/impl/adagrad.py:59
  /home/travis/build/scikit-learn-contrib/lightning/lightning/impl/adagrad.py:59: DeprecationWarning: invalid escape sequence \s
    """
```