### PR TITLE
add Cython directives to pxd files

### DIFF
--- a/lightning/impl/dataset_fast.pxd
+++ b/lightning/impl/dataset_fast.pxd
@@ -1,3 +1,9 @@
+# encoding: utf-8
+# cython: cdivision=True
+# cython: boundscheck=False
+# cython: wraparound=False
+# cython: language_level=3
+#
 # Author: Mathieu Blondel
 # License: BSD
 

--- a/lightning/impl/prox_fast.pxd
+++ b/lightning/impl/prox_fast.pxd
@@ -1,3 +1,11 @@
+# encoding: utf-8
+# cython: cdivision=True
+# cython: boundscheck=False
+# cython: wraparound=False
+# cython: language_level=3
+#
+# Authors: Fabian Pedregosa
+# License: BSD
 
 cimport numpy as np
 from cython cimport floating

--- a/lightning/impl/prox_fast.pyx
+++ b/lightning/impl/prox_fast.pyx
@@ -5,7 +5,7 @@
 # cython: language_level=3
 #
 # Authors: Fabian Pedregosa
-#
+# License: BSD
 
 """
 These are some helper functions to compute the proximal operator of some common penalties

--- a/lightning/impl/randomkit/random_fast.pxd
+++ b/lightning/impl/randomkit/random_fast.pxd
@@ -1,3 +1,10 @@
+# encoding: utf-8
+# cython: cdivision=True
+# cython: boundscheck=False
+# cython: wraparound=False
+# cython: language_level=3
+#
+# Copyright 2005 Robert Kern (robert.kern@gmail.com)
 
 cdef extern from "randomkit.h":
 

--- a/lightning/impl/randomkit/random_fast.pyx
+++ b/lightning/impl/randomkit/random_fast.pyx
@@ -1,3 +1,9 @@
+# encoding: utf-8
+# cython: cdivision=True
+# cython: boundscheck=False
+# cython: wraparound=False
+# cython: language_level=3
+#
 # Copyright 2005 Robert Kern (robert.kern@gmail.com)
 
 from libc cimport stdlib

--- a/lightning/impl/sag_fast.pxd
+++ b/lightning/impl/sag_fast.pxd
@@ -1,3 +1,13 @@
+# encoding: utf-8
+# cython: cdivision=True
+# cython: boundscheck=False
+# cython: wraparound=False
+# cython: language_level=3
+#
+# Authors: Mathieu Blondel
+#          Fabian Pedregosa
+#          Arnaud Rachez
+# License: BSD
 
 cimport numpy as np
 

--- a/lightning/impl/sgd_fast.pxd
+++ b/lightning/impl/sgd_fast.pxd
@@ -1,4 +1,11 @@
+# encoding: utf-8
+# cython: cdivision=True
+# cython: boundscheck=False
+# cython: wraparound=False
+# cython: language_level=3
+#
 # Author: Mathieu Blondel
+#         Peter Prettenhofer (loss functions)
 # License: BSD
 
 cdef class LossFunction:


### PR DESCRIPTION
Fix
```
/home/travis/miniconda/envs/test-environment/lib/python3.6/site-packages/Cython/Compiler/Main.py:369: FutureWarning: Cython directive 'language_level' not set, using 2 for now (Py2). This will change in a later release! File: /home/travis/build/scikit-learn-contrib/lightning/lightning/impl/dataset_fast.pxd
```

Linking #134.