### PR TITLE
execute all examples in gallery and prettify printed info

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -68,6 +68,7 @@ exclude_patterns = ['_build', '_templates', '_themes', 'Thumbs.db', '.DS_Store']
 sphinx_gallery_conf = {
      'examples_dirs': '../examples',
      'gallery_dirs': 'auto_examples',
+     'filename_pattern' : '.py',
      'plot_gallery': 'True',
 }
 

--- a/examples/document_classification_news20.py
+++ b/examples/document_classification_news20.py
@@ -7,11 +7,7 @@ Classification of text documents
 import numpy as np
 
 from sklearn.datasets import fetch_20newsgroups_vectorized
-
-try:
-    from sklearn.model_selection import train_test_split
-except ImportError:
-    from sklearn.cross_validation import train_test_split
+from sklearn.model_selection import train_test_split
     
 from lightning.classification import CDClassifier
 from lightning.classification import LinearSVC
@@ -50,4 +46,4 @@ clfs = (CDClassifier(loss="squared_hinge",
 for clf in clfs:
     print(clf.__class__.__name__)
     clf.fit(X_tr, y_tr)
-    print(clf.score(X_te, y_te))
+    print("score =", clf.score(X_te, y_te))

--- a/examples/plot_sparse_non_linear.py
+++ b/examples/plot_sparse_non_linear.py
@@ -3,18 +3,18 @@
 Sparse non-linear classification
 ================================
 
-This examples demonstrates how to use `CDClassifier` with L1 penalty to do
+This examples demonstrates how to use :class:`lightning.classification.CDClassifier` with L1 penalty to do
 sparse non-linear classification. The trick simply consists in fitting the
 classifier with a kernel matrix (e.g., using an RBF kernel).
 
 There are a few interesting differences with standard kernel SVMs:
 
 1. the kernel matrix does not need to be positive semi-definite (hence the
-expression "kernel matrix" above is an abuse of terminology)
+   expression "kernel matrix" above is an abuse of terminology)
 
 2. the number of "support vectors" will be typically smaller thanks to L1
-regularization and can be adjusted by the regularization parameter C (the
-smaller C, the fewer the support vectors)
+   regularization and can be adjusted by the regularization parameter C (the
+   smaller C, the fewer the support vectors)
 
 3. the "support vectors" need not be located at the margin
 """

--- a/examples/trace.py
+++ b/examples/trace.py
@@ -36,9 +36,8 @@ clf = FistaClassifier(C=1.0 / X_train.shape[0],
                       penalty="trace",
                       multiclass=True)
 
+print(f"{'alpha': <10}| {'score': <25}| {'rank': <5}")
 for alpha in (1e-3, 1e-2, 0.1, 0.2, 0.3):
-    print("alpha=", alpha)
     clf.alpha = alpha
     clf.fit(X_train, y_train)
-    print(clf.score(X_test, y_test))
-    print(rank(clf.coef_))
+    print(f"{alpha: <10}| {clf.score(X_test, y_test): <25}| {rank(clf.coef_): <5}")


### PR DESCRIPTION
By executing all examples regardless they have plots or not, we make sure they are runnable and up-to-date.
> By default, Sphinx-Gallery will **parse and add** all files with a `.py` extension to the gallery, but only **execute** files beginning with `plot_`.
   https://sphinx-gallery.github.io/stable/configuration.html#parsing-and-executing-examples-via-matching-patterns