### PR TITLE
Drop Python 3.6 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,16 +23,12 @@ jobs:
           - macos-latest
           - windows-latest
         python_version:
-          - '3.6'
           - '3.7'
           - '3.8'
           - '3.9'
         python_arch:
           - x64
         include:
-          - os: windows-latest
-            python_version: '3.6'
-            python_arch: x86
           - os: windows-latest
             python_version: '3.7'
             python_arch: x86

--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ penalty on the News20 dataset (c.f., `Blondel et al. 2013
 Dependencies
 ------------
 
-lightning requires Python >= 3.6, setuptools, Joblib, Numpy >= 1.12, SciPy >= 0.19 and
+lightning requires Python >= 3.7, setuptools, Joblib, Numpy >= 1.12, SciPy >= 0.19 and
 scikit-learn >= 0.19. Building from source also requires Cython and a working C/C++ compiler. To run the tests you will also need pytest.
 
 Installation

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with open(os.path.join('lightning', '__init__.py'), encoding='utf-8') as f:
     match = re.search(r'__version__[ ]*=[ ]*[\"\'](?P<version>.+)[\"\']',
                       f.read())
     VERSION = match.group('version').strip()
-MIN_PYTHON_VERSION = '3.6'
+MIN_PYTHON_VERSION = '3.7'
 with open('requirements.txt', encoding='utf-8') as f:
     REQUIREMENTS = [
         line.strip()


### PR DESCRIPTION
Python 3.6 is reaching its End of Life tomorrow and no need to support it anymore.
https://devguide.python.org/#branchstatus