### PR TITLE
Fix documentation building

### DIFF
--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -3,7 +3,7 @@ name: Deploy Docs to GitHub Pages
 on:
   push:
     branches:
-      - fix_gh_pages
+      - master
 
 jobs:
   build-and-deploy-docs:

--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -3,7 +3,7 @@ name: Deploy Docs to GitHub Pages
 on:
   push:
     branches:
-      - master
+      - fix_gh_pages
 
 jobs:
   build-and-deploy-docs:
@@ -16,7 +16,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
+          python-version: '3.9'
       - name: Install package
         run: |
           pip install -r requirements_build.txt
@@ -27,7 +27,7 @@ jobs:
           pip install -r requirements.txt
           make html
       - name: Deploy docs
-        uses: JamesIves/github-pages-deploy-action@4.1.3
+        uses: JamesIves/github-pages-deploy-action@4.1.8
         with:
           branch: gh-pages
           folder: ${{ github.workspace }}/doc/_build/html


### PR DESCRIPTION
Pin Python version to `3.9` in docs generating workflow (default is `3.10`) to avoid installing `scipy` from sources and the following error:
```
Processing dependencies for sklearn-contrib-lightning==0.6.2.dev0
Searching for scipy
Reading https://pypi.org/simple/scipy/
Downloading https://files.pythonhosted.org/packages/29/d2/151a54944b333e465f98804dced31dab1284f3c37b752b9cefa710b64681/scipy-1.8.0rc2.tar.gz#sha256=d73b13eb0452c178f946b4db60b27e400225df02e926609652ed67798054e77d
Best match: scipy 1.8.0rc2
Processing scipy-1.8.0rc2.tar.gz
Writing /tmp/easy_install-we9rlw9q/scipy-1.8.0rc2/setup.cfg
Running scipy-1.8.0rc2/setup.py -q bdist_egg --dist-dir /tmp/easy_install-we9rlw9q/scipy-1.8.0rc2/egg-dist-tmp-r9r7tpz2
/tmp/easy_install-we9rlw9q/scipy-1.8.0rc2/setup.py:481: UserWarning: Unrecognized setuptools command ('-q bdist_egg --dist-dir /tmp/easy_install-we9rlw9q/scipy-1.8.0rc2/egg-dist-tmp-r9r7tpz2'), proceeding with generating Cython sources and expanding templates
  warnings.warn("Unrecognized setuptools command ('{}'), proceeding with "
error: Setup script exited with 1
Error: 'pybind11' must be installed before running the build.
```

Also, update `github-pages-deploy-action`'s version to fetch all recent bugfixes and security updates.

I've tested this PR - works fine: https://github.com/scikit-learn-contrib/lightning/runs/4637378443?check_suite_focus=true