### PR TITLE
Refactor tests to use pytest features

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Package tests
 on:
   push:
     branches:
-      - pytest
+      - master
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
   pull_request:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Package tests
 on:
   push:
     branches:
-      - master
+      - pytest
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
   pull_request:

--- a/lightning/impl/tests/conftest.py
+++ b/lightning/impl/tests/conftest.py
@@ -9,8 +9,7 @@ from lightning.impl.datasets.samples_generator import make_classification
 @pytest.fixture(scope="module")
 def train_data():
     iris = load_iris()
-    X, y = iris.data, iris.target
-    return X, y
+    return iris.data, iris.target
 
 
 @pytest.fixture(scope="module")
@@ -31,7 +30,7 @@ def bin_dense_train_data():
 
 @pytest.fixture(scope="module")
 def bin_sparse_train_data(bin_dense_train_data):
-    bin_dense, bin_target = bin_dense, bin_target
+    bin_dense, bin_target = bin_dense_train_data
     bin_csr = sp.csr_matrix(bin_dense)
     return bin_csr, bin_target
 

--- a/lightning/impl/tests/conftest.py
+++ b/lightning/impl/tests/conftest.py
@@ -1,0 +1,51 @@
+import pytest
+import scipy.sparse as sp
+
+from sklearn.datasets import load_iris
+
+from lightning.impl.datasets.samples_generator import make_classification
+
+
+@pytest.fixture(scope="module")
+def train_data():
+    iris = load_iris()
+    X, y = iris.data, iris.target
+    return X, y
+
+
+@pytest.fixture(scope="module")
+def bin_train_data(train_data):
+    X, y = train_data
+    X_bin = X[y <= 1]
+    y_bin = y[y <= 1] * 2 - 1
+    return X_bin, y_bin
+
+
+@pytest.fixture(scope="module")
+def bin_dense_train_data():
+    bin_dense, bin_target = make_classification(n_samples=200, n_features=100,
+                                                n_informative=5,
+                                                n_classes=2, random_state=0)
+    return bin_dense, bin_target
+
+
+@pytest.fixture(scope="module")
+def bin_sparse_train_data(bin_dense_train_data):
+    bin_dense, bin_target = bin_dense, bin_target
+    bin_csr = sp.csr_matrix(bin_dense)
+    return bin_csr, bin_target
+
+
+@pytest.fixture(scope="module")
+def mult_dense_train_data():
+    mult_dense, mult_target = make_classification(n_samples=300, n_features=100,
+                                                  n_informative=5,
+                                                  n_classes=3, random_state=0)
+    return mult_dense, mult_target
+
+
+@pytest.fixture(scope="module")
+def mult_sparse_train_data(mult_dense_train_data):
+    mult_dense, mult_target = mult_dense_train_data
+    mult_sparse = sp.csr_matrix(mult_dense)
+    return mult_sparse, mult_target

--- a/lightning/impl/tests/test_adagrad.py
+++ b/lightning/impl/tests/test_adagrad.py
@@ -1,27 +1,22 @@
 import numpy as np
-
-from sklearn.datasets import load_iris
+import pytest
 
 from lightning.classification import AdaGradClassifier
 from lightning.regression import AdaGradRegressor
 from lightning.impl.adagrad_fast import _proj_elastic_all
 from lightning.impl.tests.utils import check_predict_proba
 
-iris = load_iris()
-X, y = iris.data, iris.target
 
-X_bin = X[y <= 1]
-y_bin = y[y <= 1] * 2 - 1
-
-
-def test_adagrad_elastic_hinge():
+def test_adagrad_elastic_hinge(bin_train_data):
+    X_bin, y_bin = bin_train_data
     clf = AdaGradClassifier(alpha=0.5, l1_ratio=0.85, n_iter=10, random_state=0)
     clf.fit(X_bin, y_bin)
     assert not hasattr(clf, "predict_proba")
     assert clf.score(X_bin, y_bin) == 1.0
 
 
-def test_adagrad_elastic_smooth_hinge():
+def test_adagrad_elastic_smooth_hinge(bin_train_data):
+    X_bin, y_bin = bin_train_data
     clf = AdaGradClassifier(alpha=0.5, l1_ratio=0.85, loss="smooth_hinge",
                             n_iter=10, random_state=0)
     clf.fit(X_bin, y_bin)
@@ -29,7 +24,8 @@ def test_adagrad_elastic_smooth_hinge():
     assert clf.score(X_bin, y_bin) == 1.0
 
 
-def test_adagrad_elastic_log():
+def test_adagrad_elastic_log(bin_train_data):
+    X_bin, y_bin = bin_train_data
     clf = AdaGradClassifier(alpha=0.1, l1_ratio=0.85, loss="log", n_iter=10,
                             random_state=0)
     clf.fit(X_bin, y_bin)
@@ -37,28 +33,31 @@ def test_adagrad_elastic_log():
     check_predict_proba(clf, X_bin)
 
 
-def test_adagrad_hinge_multiclass():
+def test_adagrad_hinge_multiclass(train_data):
+    X, y = train_data
     clf = AdaGradClassifier(alpha=1e-2, n_iter=100, loss="hinge", random_state=0)
     clf.fit(X, y)
     assert not hasattr(clf, "predict_proba")
     np.testing.assert_almost_equal(clf.score(X, y), 0.940, 3)
 
 
-def test_adagrad_classes_binary():
+def test_adagrad_classes_binary(bin_train_data):
+    X_bin, y_bin = bin_train_data
     clf = AdaGradClassifier()
     assert not hasattr(clf, 'classes_')
     clf.fit(X_bin, y_bin)
     assert list(clf.classes_) == [-1, 1]
 
 
-def test_adagrad_classes_multiclass():
+def test_adagrad_classes_multiclass(train_data):
+    X, y = train_data
     clf = AdaGradClassifier()
     assert not hasattr(clf, 'classes_')
     clf.fit(X, y)
     assert list(clf.classes_) == [0, 1, 2]
 
 
-def test_adagrad_callback():
+def test_adagrad_callback(bin_train_data):
     class Callback(object):
 
         def __init__(self, X, y):
@@ -74,6 +73,7 @@ def test_adagrad_callback():
             score = clf.score(self.X, self.y)
             self.acc.append(score)
 
+    X_bin, y_bin = bin_train_data
     cb = Callback(X_bin, y_bin)
     clf = AdaGradClassifier(alpha=0.5, l1_ratio=0.85, n_iter=10,
                             callback=cb, random_state=0)
@@ -81,9 +81,10 @@ def test_adagrad_callback():
     assert cb.acc[-1] == 1.0
 
 
-def test_adagrad_regression():
-    for loss in ("squared", "absolute"):
-        reg = AdaGradRegressor(loss=loss)
-        reg.fit(X_bin, y_bin)
-        y_pred = np.sign(reg.predict(X_bin))
-        assert np.mean(y_bin == y_pred) == 1.0
+@pytest.mark.parametrize("loss", ["squared", "absolute"])
+def test_adagrad_regression(loss, bin_train_data):
+    X_bin, y_bin = bin_train_data
+    reg = AdaGradRegressor(loss=loss)
+    reg.fit(X_bin, y_bin)
+    y_pred = np.sign(reg.predict(X_bin))
+    assert np.mean(y_bin == y_pred) == 1.0

--- a/lightning/impl/tests/test_dataset.py
+++ b/lightning/impl/tests/test_dataset.py
@@ -55,7 +55,7 @@ def test_csr_get_row(test_data):
 
 
 def test_fortran_get_column(test_data):
-    X, _, _, cds, fds, _, _ = test_data
+    X, _, _, _, fds, _, _ = test_data
     ind = np.arange(X.shape[0])
     for j in range(X.shape[1]):
         indices, data, n_nz = fds.get_column(j)

--- a/lightning/impl/tests/test_dataset.py
+++ b/lightning/impl/tests/test_dataset.py
@@ -1,5 +1,7 @@
 import pickle
+
 import numpy as np
+import pytest
 import scipy.sparse as sp
 
 from sklearn.datasets import make_classification
@@ -10,26 +12,31 @@ from lightning.impl.dataset_fast import FortranDataset
 from lightning.impl.dataset_fast import CSRDataset
 from lightning.impl.dataset_fast import CSCDataset
 
-# Create test datasets.
-X, _ = make_classification(n_samples=20, n_features=100,
-                           n_informative=5, n_classes=2, random_state=0)
-X2, _ = make_classification(n_samples=10, n_features=100,
-                            n_informative=5, n_classes=2, random_state=0)
 
-# Sparsify datasets.
-X[X < 0.3] = 0
+@pytest.fixture(scope="module")
+def test_data():
+    X, _ = make_classification(n_samples=20, n_features=100,
+                               n_informative=5, n_classes=2, random_state=0)
+    X2, _ = make_classification(n_samples=10, n_features=100,
+                                n_informative=5, n_classes=2, random_state=0)
 
-X_csr = sp.csr_matrix(X)
-X_csc = sp.csc_matrix(X)
+    # Sparsify datasets.
+    X[X < 0.3] = 0
 
-rs = check_random_state(0)
-cds = ContiguousDataset(X)
-fds = FortranDataset(np.asfortranarray(X))
-csr_ds = CSRDataset(X_csr)
-csc_ds = CSCDataset(X_csc)
+    X_csr = sp.csr_matrix(X)
+    X_csc = sp.csc_matrix(X)
+
+    rs = check_random_state(0)
+    cds = ContiguousDataset(X)
+    fds = FortranDataset(np.asfortranarray(X))
+    csr_ds = CSRDataset(X_csr)
+    csc_ds = CSCDataset(X_csc)
+
+    return X, X_csr, X_csc, cds, fds, csr_ds, csc_ds
 
 
-def test_contiguous_get_row():
+def test_contiguous_get_row(test_data):
+    X, _, _, cds, _, _, _ = test_data
     ind = np.arange(X.shape[1])
     for i in range(X.shape[0]):
         indices, data, n_nz = cds.get_row(i)
@@ -38,7 +45,8 @@ def test_contiguous_get_row():
         assert n_nz == X.shape[1]
 
 
-def test_csr_get_row():
+def test_csr_get_row(test_data):
+    X, _, _, _, _, csr_ds, _ = test_data
     for i in range(X.shape[0]):
         indices, data, n_nz = csr_ds.get_row(i)
         for jj in range(n_nz):
@@ -46,7 +54,8 @@ def test_csr_get_row():
             assert X[i, j] == data[jj]
 
 
-def test_fortran_get_column():
+def test_fortran_get_column(test_data):
+    X, _, _, cds, fds, _, _ = test_data
     ind = np.arange(X.shape[0])
     for j in range(X.shape[1]):
         indices, data, n_nz = fds.get_column(j)
@@ -55,7 +64,8 @@ def test_fortran_get_column():
         assert n_nz == X.shape[0]
 
 
-def test_csc_get_column():
+def test_csc_get_column(test_data):
+    X, _, _, _, _, _, csc_ds = test_data
     for j in range(X.shape[1]):
         indices, data, n_nz = csc_ds.get_column(j)
         for ii in range(n_nz):
@@ -63,9 +73,9 @@ def test_csc_get_column():
             assert X[i, j] == data[ii]
 
 
-def test_picklable_datasets():
-    """Test that the datasets are picklable."""
-
+def test_picklable_datasets(test_data):
+    # Test that the datasets are picklable.
+    X, _, _, cds, fds, csr_ds, csc_ds = test_data
     for dataset in [cds, csr_ds, fds, csc_ds]:
         pds = pickle.dumps(dataset)
         dataset = pickle.loads(pds)

--- a/lightning/impl/tests/test_dataset.py
+++ b/lightning/impl/tests/test_dataset.py
@@ -32,11 +32,20 @@ def test_data():
     csr_ds = CSRDataset(X_csr)
     csc_ds = CSCDataset(X_csc)
 
-    return X, X_csr, X_csc, cds, fds, csr_ds, csc_ds
+    return {
+        "X": X,
+        "X_csr": X_csr,
+        "X_csc": X_csc,
+        "contiguous_dataset": cds,
+        "fortran_dataset": fds,
+        "dataset_csr": csr_ds,
+        "dataset_csc": csc_ds
+    }
 
 
 def test_contiguous_get_row(test_data):
-    X, _, _, cds, _, _, _ = test_data
+    X = test_data["X"]
+    cds = test_data["contiguous_dataset"]
     ind = np.arange(X.shape[1])
     for i in range(X.shape[0]):
         indices, data, n_nz = cds.get_row(i)
@@ -46,7 +55,8 @@ def test_contiguous_get_row(test_data):
 
 
 def test_csr_get_row(test_data):
-    X, _, _, _, _, csr_ds, _ = test_data
+    X = test_data["X"]
+    csr_ds = test_data["dataset_csr"]
     for i in range(X.shape[0]):
         indices, data, n_nz = csr_ds.get_row(i)
         for jj in range(n_nz):
@@ -55,7 +65,8 @@ def test_csr_get_row(test_data):
 
 
 def test_fortran_get_column(test_data):
-    X, _, _, _, fds, _, _ = test_data
+    X = test_data["X"]
+    fds = test_data["fortran_dataset"]
     ind = np.arange(X.shape[0])
     for j in range(X.shape[1]):
         indices, data, n_nz = fds.get_column(j)
@@ -65,7 +76,8 @@ def test_fortran_get_column(test_data):
 
 
 def test_csc_get_column(test_data):
-    X, _, _, _, _, _, csc_ds = test_data
+    X = test_data["X"]
+    csc_ds = test_data["dataset_csc"]
     for j in range(X.shape[1]):
         indices, data, n_nz = csc_ds.get_column(j)
         for ii in range(n_nz):
@@ -75,8 +87,13 @@ def test_csc_get_column(test_data):
 
 def test_picklable_datasets(test_data):
     # Test that the datasets are picklable.
-    X, _, _, cds, fds, csr_ds, csc_ds = test_data
-    for dataset in [cds, csr_ds, fds, csc_ds]:
+    X = test_data["X"]
+    for dataset in [
+        test_data["contiguous_dataset"],
+        test_data["dataset_csr"],
+        test_data["fortran_dataset"],
+        test_data["dataset_csc"]
+    ]:
         pds = pickle.dumps(dataset)
         dataset = pickle.loads(pds)
         assert dataset.get_n_samples() == X.shape[0]

--- a/lightning/impl/tests/test_dual_cd.py
+++ b/lightning/impl/tests/test_dual_cd.py
@@ -17,48 +17,49 @@ def reg_train_data():
     return reg_dense, reg_target
 
 
-@pytest.mark.parametrize("data", [bin_dense_train_data[0], bin_sparse_train_data[0]])
+@pytest.mark.parametrize("data", [bin_dense_train_data, bin_sparse_train_data])
 def test_sparse_dot(data):
-    K = linear_kernel(data)
+    X, _ = data
+    K = linear_kernel(X)
     K2 = np.zeros_like(K)
-    ds = get_dataset(data)
+    ds = get_dataset(X)
 
-    for i in range(data.shape[0]):
-        for j in range(i, data.shape[0]):
+    for i in range(X.shape[0]):
+        for j in range(i, X.shape[0]):
             K2[i, j] = sparse_dot(ds, i, j)
             K2[j, i] = K[i, j]
 
     np.testing.assert_array_almost_equal(K, K2)
 
 
-@pytest.mark.parametrize("data", [bin_dense_train_data[0], bin_sparse_train_data[0]])
+@pytest.mark.parametrize("data", [bin_dense_train_data, bin_sparse_train_data])
 @pytest.mark.parametrize("loss", ["l1", "l2"])
-def test_fit_linear_binary(bin_dense_train_data, data, loss):
-    _, bin_target = bin_dense_train_data
+def test_fit_linear_binary(data, loss):
+    X, y = data
     clf = LinearSVC(loss=loss, random_state=0, max_iter=10)
-    clf.fit(data, bin_target)
+    clf.fit(X, y)
     assert list(clf.classes_) == [0, 1]
-    assert clf.score(data, bin_target) == 1.0
-    y_pred = clf.decision_function(data).ravel()
+    assert clf.score(X, y) == 1.0
+    y_pred = clf.decision_function(X).ravel()
 
 
-@pytest.mark.parametrize("data", [bin_dense_train_data[0], bin_sparse_train_data[0]])
+@pytest.mark.parametrize("data", [bin_dense_train_data, bin_sparse_train_data])
 @pytest.mark.parametrize("loss", ["l1", "l2"])
-def test_fit_linear_binary_auc(bin_dense_train_data, data, loss):
-    _, bin_target = bin_dense_train_data
+def test_fit_linear_binary_auc(data, loss):
+    X, y = data
     clf = LinearSVC(loss=loss, criterion="auc", random_state=0, max_iter=25)
-    clf.fit(data, bin_target)
-    assert clf.score(data, bin_target) == 1.0
+    clf.fit(X, y)
+    assert clf.score(X, y) == 1.0
 
 
-@pytest.mark.parametrize("data", [mult_dense_train_data[0], mult_sparse_train_data[0]])
-def test_fit_linear_multi(mult_dense_train_data, data):
-    _, mult_target = mult_dense_train_data
+@pytest.mark.parametrize("data", [mult_dense_train_data, mult_sparse_train_data])
+def test_fit_linear_multi(data):
+    X, y = data
     clf = LinearSVC(random_state=0)
-    clf.fit(data, mult_target)
+    clf.fit(X, y)
     assert list(clf.classes_) == [0, 1, 2]
-    y_pred = clf.predict(data)
-    acc = np.mean(y_pred == mult_target)
+    y_pred = clf.predict(X)
+    acc = np.mean(y_pred == y)
     assert acc > 0.85
 
 

--- a/lightning/impl/tests/test_dual_cd.py
+++ b/lightning/impl/tests/test_dual_cd.py
@@ -17,9 +17,9 @@ def reg_train_data():
     return reg_dense, reg_target
 
 
-@pytest.mark.parametrize("data", [bin_dense_train_data, bin_sparse_train_data])
-def test_sparse_dot(data):
-    X, _ = data
+@pytest.mark.parametrize("data", ["bin_dense_train_data", "bin_sparse_train_data"])
+def test_sparse_dot(data, request):
+    X, _ = request.getfixturevalue(data)
     K = linear_kernel(X)
     K2 = np.zeros_like(K)
     ds = get_dataset(X)
@@ -32,10 +32,10 @@ def test_sparse_dot(data):
     np.testing.assert_array_almost_equal(K, K2)
 
 
-@pytest.mark.parametrize("data", [bin_dense_train_data, bin_sparse_train_data])
+@pytest.mark.parametrize("data", ["bin_dense_train_data", "bin_sparse_train_data"])
 @pytest.mark.parametrize("loss", ["l1", "l2"])
-def test_fit_linear_binary(data, loss):
-    X, y = data
+def test_fit_linear_binary(data, loss, request):
+    X, y = request.getfixturevalue(data)
     clf = LinearSVC(loss=loss, random_state=0, max_iter=10)
     clf.fit(X, y)
     assert list(clf.classes_) == [0, 1]
@@ -43,18 +43,18 @@ def test_fit_linear_binary(data, loss):
     y_pred = clf.decision_function(X).ravel()
 
 
-@pytest.mark.parametrize("data", [bin_dense_train_data, bin_sparse_train_data])
+@pytest.mark.parametrize("data", ["bin_dense_train_data", "bin_sparse_train_data"])
 @pytest.mark.parametrize("loss", ["l1", "l2"])
-def test_fit_linear_binary_auc(data, loss):
-    X, y = data
+def test_fit_linear_binary_auc(data, loss, request):
+    X, y = request.getfixturevalue(data)
     clf = LinearSVC(loss=loss, criterion="auc", random_state=0, max_iter=25)
     clf.fit(X, y)
     assert clf.score(X, y) == 1.0
 
 
-@pytest.mark.parametrize("data", [mult_dense_train_data, mult_sparse_train_data])
-def test_fit_linear_multi(data):
-    X, y = data
+@pytest.mark.parametrize("data", ["mult_dense_train_data", "mult_sparse_train_data"])
+def test_fit_linear_multi(data, request):
+    X, y = request.getfixturevalue(data)
     clf = LinearSVC(random_state=0)
     clf.fit(X, y)
     assert list(clf.classes_) == [0, 1, 2]

--- a/lightning/impl/tests/test_dual_cd.py
+++ b/lightning/impl/tests/test_dual_cd.py
@@ -1,105 +1,90 @@
 import numpy as np
-import scipy.sparse as sp
+import pytest
 
 from sklearn.metrics.pairwise import linear_kernel
 from sklearn.datasets import make_regression
 
-from lightning.impl.datasets.samples_generator import make_classification
 from lightning.impl.dual_cd import LinearSVC
 from lightning.impl.dual_cd import LinearSVR
 from lightning.impl.dual_cd_fast import sparse_dot
 from lightning.impl.dataset_fast import get_dataset
 
-bin_dense, bin_target = make_classification(n_samples=200, n_features=100,
-                                            n_informative=5,
-                                            n_classes=2, random_state=0)
-bin_csr = sp.csr_matrix(bin_dense)
 
-mult_dense, mult_target = make_classification(n_samples=300, n_features=100,
-                                              n_informative=5,
-                                              n_classes=3, random_state=0)
-mult_sparse = sp.csr_matrix(mult_dense)
-
-reg_dense, reg_target = make_regression(n_samples=200, n_features=100,
-                                        n_informative=5, random_state=0)
+@pytest.fixture(scope="module")
+def reg_train_data():
+    reg_dense, reg_target = make_regression(n_samples=200, n_features=100,
+                                            n_informative=5, random_state=0)
+    return reg_dense, reg_target
 
 
-def test_sparse_dot():
-    for data in (bin_dense, bin_csr):
-        K = linear_kernel(data)
-        K2 = np.zeros_like(K)
-        ds = get_dataset(data)
+@pytest.mark.parametrize("data", [bin_dense_train_data[0], bin_sparse_train_data[0]])
+def test_sparse_dot(data):
+    K = linear_kernel(data)
+    K2 = np.zeros_like(K)
+    ds = get_dataset(data)
 
-        for i in range(data.shape[0]):
-            for j in range(i, data.shape[0]):
-                K2[i, j] = sparse_dot(ds, i, j)
-                K2[j, i] = K[i, j]
+    for i in range(data.shape[0]):
+        for j in range(i, data.shape[0]):
+            K2[i, j] = sparse_dot(ds, i, j)
+            K2[j, i] = K[i, j]
 
     np.testing.assert_array_almost_equal(K, K2)
 
 
-def test_fit_linear_binary():
-    for data in (bin_dense, bin_csr):
-        for loss in ("l1", "l2"):
-            clf = LinearSVC(loss=loss, random_state=0, max_iter=10)
-            clf.fit(data, bin_target)
-            assert list(clf.classes_) == [0, 1]
-            assert clf.score(data, bin_target) == 1.0
-            y_pred = clf.decision_function(data).ravel()
+@pytest.mark.parametrize("data", [bin_dense_train_data[0], bin_sparse_train_data[0]])
+@pytest.mark.parametrize("loss", ["l1", "l2"])
+def test_fit_linear_binary(bin_dense_train_data, data, loss):
+    _, bin_target = bin_dense_train_data
+    clf = LinearSVC(loss=loss, random_state=0, max_iter=10)
+    clf.fit(data, bin_target)
+    assert list(clf.classes_) == [0, 1]
+    assert clf.score(data, bin_target) == 1.0
+    y_pred = clf.decision_function(data).ravel()
 
 
-def test_fit_linear_binary_auc():
-    for data in (bin_dense, bin_csr):
-        for loss in ("l1", "l2"):
-            clf = LinearSVC(loss=loss, criterion="auc", random_state=0,
-                            max_iter=25)
-            clf.fit(data, bin_target)
-            assert clf.score(data, bin_target) == 1.0
+@pytest.mark.parametrize("data", [bin_dense_train_data[0], bin_sparse_train_data[0]])
+@pytest.mark.parametrize("loss", ["l1", "l2"])
+def test_fit_linear_binary_auc(bin_dense_train_data, data, loss):
+    _, bin_target = bin_dense_train_data
+    clf = LinearSVC(loss=loss, criterion="auc", random_state=0, max_iter=25)
+    clf.fit(data, bin_target)
+    assert clf.score(data, bin_target) == 1.0
 
 
-def test_fit_linear_multi():
-    for data in (mult_dense, mult_sparse):
-        clf = LinearSVC(random_state=0)
-        clf.fit(data, mult_target)
-        assert list(clf.classes_) == [0, 1, 2]
-        y_pred = clf.predict(data)
-        acc = np.mean(y_pred == mult_target)
-        assert acc > 0.85
+@pytest.mark.parametrize("data", [mult_dense_train_data[0], mult_sparse_train_data[0]])
+def test_fit_linear_multi(mult_dense_train_data, data):
+    _, mult_target = mult_dense_train_data
+    clf = LinearSVC(random_state=0)
+    clf.fit(data, mult_target)
+    assert list(clf.classes_) == [0, 1, 2]
+    y_pred = clf.predict(data)
+    acc = np.mean(y_pred == mult_target)
+    assert acc > 0.85
 
 
-def test_warm_start():
+@pytest.mark.parametrize("C", [0.1, 0.2])
+def test_warm_start(bin_dense_train_data, C):
+    bin_dense, bin_target = bin_dense_train_data
     clf = LinearSVC(warm_start=True, loss="l1", random_state=0, max_iter=100)
-    for C in (0.1, 0.2):
-        clf.C = C
-
-        clf.fit(bin_dense, bin_target)
-        acc = clf.score(bin_dense, bin_target)
-        assert acc > 0.99
+    clf.C = C
+    clf.fit(bin_dense, bin_target)
+    acc = clf.score(bin_dense, bin_target)
+    assert acc > 0.99
 
 
-def test_linear_svr():
-    reg = LinearSVR(random_state=0)
+@pytest.mark.parametrize("fit_intercept", [True, False])
+@pytest.mark.parametrize("loss", ["epsilon_insensitive", "l2"])
+def test_linear_svr(reg_train_data, fit_intercept, loss):
+    reg_dense, reg_target = reg_train_data
+    reg = LinearSVR(random_state=0, fit_intercept=fit_intercept, loss=loss)
     reg.fit(reg_dense, reg_target)
     assert reg.score(reg_dense, reg_target) > 0.99
 
 
-def test_linear_svr_fit_intercept():
-    reg = LinearSVR(random_state=0, fit_intercept=True)
+@pytest.mark.parametrize("C, warm_start", [(1e-3, True), (1, False)])
+def test_linear_svr_warm_start(reg_train_data, C, warm_start):
+    reg_dense, reg_target = reg_train_data
+    reg = LinearSVR(C=C, random_state=0, warm_start=warm_start)
     reg.fit(reg_dense, reg_target)
-    assert reg.score(reg_dense, reg_target) > 0.99
-
-
-def test_linear_svr_l2():
-    reg = LinearSVR(loss="l2", random_state=0)
-    reg.fit(reg_dense, reg_target)
-    assert reg.score(reg_dense, reg_target) > 0.99
-
-
-def test_linear_svr_warm_start():
-    reg = LinearSVR(C=1e-3, random_state=0, warm_start=True)
-    reg.fit(reg_dense, reg_target)
-    assert reg.score(reg_dense, reg_target) > 0.96
-
-    reg.C = 1
-    reg.fit(reg_dense, reg_target)
-    assert reg.score(reg_dense, reg_target) > 0.99
+    target_score = 0.99 if C == 1 else 0.96
+    assert reg.score(reg_dense, reg_target) > target_score

--- a/lightning/impl/tests/test_fista.py
+++ b/lightning/impl/tests/test_fista.py
@@ -1,126 +1,123 @@
 import numpy as np
-import scipy.sparse as sp
+import pytest
 
 from scipy.linalg import svd, diagsvd
 
-from sklearn.datasets import load_digits
-
-from lightning.impl.datasets.samples_generator import make_classification
 from lightning.classification import FistaClassifier
 from lightning.regression import FistaRegressor
-from lightning.impl.penalty import project_simplex, project_l1_ball, L1Penalty
-
-bin_dense, bin_target = make_classification(n_samples=200, n_features=100,
-                                            n_informative=5,
-                                            n_classes=2, random_state=0)
-bin_target = bin_target * 2 - 1
-
-mult_dense, mult_target = make_classification(n_samples=300, n_features=100,
-                                              n_informative=5,
-                                              n_classes=3, random_state=0)
-bin_csr = sp.csr_matrix(bin_dense)
-mult_csr = sp.csr_matrix(mult_dense)
-digit = load_digits(n_class=2)
+from lightning.impl.penalty import project_simplex, L1Penalty
 
 
-def test_fista_multiclass_l1l2():
-    for data in (mult_dense, mult_csr):
-        clf = FistaClassifier(max_iter=200, penalty="l1/l2", multiclass=True)
-        clf.fit(data, mult_target)
-        np.testing.assert_almost_equal(clf.score(data, mult_target), 0.99, 2)
+@pytest.fixture(scope="module")
+def bin_dense_train_data(bin_dense_train_data):
+    bin_dense, bin_target = bin_dense_train_data
+    bin_target = bin_target * 2 - 1
+    return bin_dense, bin_target
 
 
-def test_fista_multiclass_l1l2_log():
-    for data in (mult_dense, mult_csr):
-        clf = FistaClassifier(max_iter=200, penalty="l1/l2", loss="log",
-                              multiclass=True)
-        clf.fit(data, mult_target)
-        np.testing.assert_almost_equal(clf.score(data, mult_target), 0.90, 2)
-
-def test_fista_multiclass_l1l2_log_margin():
-    for data in (mult_dense, mult_csr):
-        clf = FistaClassifier(max_iter=200, penalty="l1/l2", loss="log_margin",
-                              multiclass=True)
-        clf.fit(data, mult_target)
-        np.testing.assert_almost_equal(clf.score(data, mult_target), 0.93, 2)
+@pytest.mark.parametrize("data", [mult_dense_train_data, mult_sparse_train_data])
+def test_fista_multiclass_l1l2(data):
+    X, y = data
+    clf = FistaClassifier(max_iter=200, penalty="l1/l2", multiclass=True)
+    clf.fit(X, y)
+    np.testing.assert_almost_equal(clf.score(X, y), 0.99, 2)
 
 
-def test_fista_multiclass_l1():
-    for data in (mult_dense, mult_csr):
-        clf = FistaClassifier(max_iter=200, penalty="l1", multiclass=True)
-        clf.fit(data, mult_target)
-        np.testing.assert_almost_equal(clf.score(data, mult_target), 0.98, 2)
+@pytest.mark.parametrize("data", [mult_dense_train_data, mult_sparse_train_data])
+def test_fista_multiclass_l1l2_log(data):
+    X, y = data
+    clf = FistaClassifier(max_iter=200, penalty="l1/l2", loss="log",
+                          multiclass=True)
+    clf.fit(X, y)
+    np.testing.assert_almost_equal(clf.score(X, y), 0.90, 2)
 
 
-
-def test_fista_multiclass_tv1d():
-    for data in (mult_dense, mult_csr):
-        clf = FistaClassifier(max_iter=200, penalty="tv1d", multiclass=True)
-        clf.fit(data, mult_target)
-        np.testing.assert_almost_equal(clf.score(data, mult_target), 0.97, 2)
-
-        # adding a lot of regularization coef_ should be constant
-        clf = FistaClassifier(max_iter=200, penalty="tv1d", multiclass=True, alpha=1e6)
-        clf.fit(data, mult_target)
-        for i in range(clf.coef_.shape[0]):
-            np.testing.assert_array_almost_equal(
-                clf.coef_[i], np.mean(clf.coef_[i]) * np.ones(data.shape[1]))
+@pytest.mark.parametrize("data", [mult_dense_train_data, mult_sparse_train_data])
+def test_fista_multiclass_l1l2_log_margin(data):
+    X, y = data
+    clf = FistaClassifier(max_iter=200, penalty="l1/l2", loss="log_margin",
+                          multiclass=True)
+    clf.fit(X, y)
+    np.testing.assert_almost_equal(clf.score(X, y), 0.93, 2)
 
 
-def test_fista_multiclass_l1l2_no_line_search():
-    for data in (mult_dense, mult_csr):
-        clf = FistaClassifier(max_iter=500, penalty="l1/l2", multiclass=True,
-                              max_steps=0)
-        clf.fit(data, mult_target)
-        np.testing.assert_almost_equal(clf.score(data, mult_target), 0.94, 2)
+@pytest.mark.parametrize("data", [mult_dense_train_data, mult_sparse_train_data])
+def test_fista_multiclass_l1(data):
+    X, y = data
+    clf = FistaClassifier(max_iter=200, penalty="l1", multiclass=True)
+    clf.fit(X, y)
+    np.testing.assert_almost_equal(clf.score(X, y), 0.98, 2)
 
 
-def test_fista_multiclass_l1_no_line_search():
-    for data in (mult_dense, mult_csr):
-        clf = FistaClassifier(max_iter=500, penalty="l1", multiclass=True,
-                              max_steps=0)
-        clf.fit(data, mult_target)
-        np.testing.assert_almost_equal(clf.score(data, mult_target), 0.94, 2)
+@pytest.mark.parametrize("data", [mult_dense_train_data, mult_sparse_train_data])
+def test_fista_multiclass_tv1d(data):
+    X, y = data
+    clf = FistaClassifier(max_iter=200, penalty="tv1d", multiclass=True)
+    clf.fit(X, y)
+    np.testing.assert_almost_equal(clf.score(X, y), 0.97, 2)
+
+    # adding a lot of regularization coef_ should be constant
+    clf = FistaClassifier(max_iter=200, penalty="tv1d", multiclass=True, alpha=1e6)
+    clf.fit(X, y)
+    for i in range(clf.coef_.shape[0]):
+        np.testing.assert_array_almost_equal(
+            clf.coef_[i], np.mean(clf.coef_[i]) * np.ones(X.shape[1]))
 
 
-def test_fista_bin_l1():
-    for data in (bin_dense, bin_csr):
-        clf = FistaClassifier(max_iter=200, penalty="l1")
-        clf.fit(data, bin_target)
-        np.testing.assert_almost_equal(clf.score(data, bin_target), 1.0, 2)
+@pytest.mark.parametrize("data", [mult_dense_train_data, mult_sparse_train_data])
+@pytest.mark.parametrize("penalty", ["l1/l2", "l1"])
+def test_fista_multiclass_no_line_search(data, penalty):
+    X, y = data
+    clf = FistaClassifier(max_iter=500, penalty=penalty, multiclass=True,
+                          max_steps=0)
+    clf.fit(X, y)
+    np.testing.assert_almost_equal(clf.score(X, y), 0.94, 2)
 
 
-def test_fista_bin_l1_no_line_search():
-    for data in (bin_dense, bin_csr):
-        clf = FistaClassifier(max_iter=500, penalty="l1", max_steps=0)
-        clf.fit(data, bin_target)
-        np.testing.assert_almost_equal(clf.score(data, bin_target), 1.0, 2)
+@pytest.mark.parametrize("data", [bin_dense_train_data, bin_sparse_train_data])
+def test_fista_bin_l1(data):
+    X, y = data
+    clf = FistaClassifier(max_iter=200, penalty="l1")
+    clf.fit(X, y)
+    np.testing.assert_almost_equal(clf.score(X, y), 1.0, 2)
 
 
-def test_fista_multiclass_trace():
-    for data in (mult_dense, mult_csr):
-        clf = FistaClassifier(max_iter=100, penalty="trace", multiclass=True)
-        clf.fit(data, mult_target)
-        np.testing.assert_almost_equal(clf.score(data, mult_target), 0.96, 2)
+@pytest.mark.parametrize("data", [bin_dense_train_data, bin_sparse_train_data])
+def test_fista_bin_l1_no_line_search(data):
+    X, y = data
+    clf = FistaClassifier(max_iter=500, penalty="l1", max_steps=0)
+    clf.fit(X, y)
+    np.testing.assert_almost_equal(clf.score(X, y), 1.0, 2)
 
 
-def test_fista_bin_classes():
+@pytest.mark.parametrize("data", [mult_dense_train_data, mult_sparse_train_data])
+def test_fista_multiclass_trace(data):
+    X, y = data
+    clf = FistaClassifier(max_iter=100, penalty="trace", multiclass=True)
+    clf.fit(X, y)
+    np.testing.assert_almost_equal(clf.score(X, y), 0.96, 2)
+
+
+def test_fista_bin_classes(bin_dense_train_data):
+    X, y = bin_dense_train_data
     clf = FistaClassifier()
-    clf.fit(bin_dense, bin_target)
+    clf.fit(X, y)
     assert list(clf.classes_) == [0, 1]
 
 
-def test_fista_multiclass_classes():
+def test_fista_multiclass_classes(mult_dense_train_data):
+    X, y = mult_dense_train_data
     clf = FistaClassifier()
-    clf.fit(mult_dense, mult_target)
+    clf.fit(X, y)
     assert list(clf.classes_) == [0, 1, 2]
 
 
-def test_fista_regression():
+def test_fista_regression(bin_dense_train_data):
+    X, y = bin_dense_train_data
     reg = FistaRegressor(max_iter=100, verbose=0)
-    reg.fit(bin_dense, bin_target)
-    y_pred = np.sign(reg.predict(bin_dense))
-    np.testing.assert_almost_equal(np.mean(bin_target == y_pred), 0.985)
+    reg.fit(X, y)
+    y_pred = np.sign(reg.predict(X))
+    np.testing.assert_almost_equal(np.mean(y == y_pred), 0.985)
 
 
 def test_fista_regression_simplex():
@@ -155,6 +152,7 @@ def test_fista_regression_l1_ball():
 
 def test_fista_regression_trace():
     rng = np.random.RandomState(0)
+
     def _make_data(n_samples, n_features, n_tasks, n_components):
         W = rng.rand(n_tasks, n_features) - 0.5
         U, S, V = svd(W, full_matrices=True)
@@ -165,7 +163,7 @@ def test_fista_regression_trace():
         Y = np.dot(X, W.T)
         return X, Y, W
 
-    X, Y, W = _make_data(200, 50,30, 5)
+    X, Y, W = _make_data(200, 50, 30, 5)
     reg = FistaRegressor(max_iter=15, verbose=0)
     reg.fit(X, Y)
     Y_pred = reg.predict(X)
@@ -174,13 +172,14 @@ def test_fista_regression_trace():
     np.testing.assert_almost_equal(error, 77.44, 2)
 
 
-def test_fista_custom_prox():
+@pytest.mark.parametrize("data", [bin_dense_train_data, bin_sparse_train_data])
+def test_fista_custom_prox(data):
     # test FISTA with a custom prox
     l1_pen = L1Penalty()
-    for data in (bin_dense, bin_csr):
-        clf = FistaClassifier(max_iter=500, penalty="l1", max_steps=0)
-        clf.fit(data, bin_target)
+    X, y = data
+    clf = FistaClassifier(max_iter=500, penalty="l1", max_steps=0)
+    clf.fit(X, y)
 
-        clf2 = FistaClassifier(max_iter=500, penalty=l1_pen, max_steps=0)
-        clf2.fit(data, bin_target)
-        np.testing.assert_array_almost_equal_nulp(clf.coef_.ravel(), clf2.coef_.ravel())
+    clf2 = FistaClassifier(max_iter=500, penalty=l1_pen, max_steps=0)
+    clf2.fit(X, y)
+    np.testing.assert_array_almost_equal_nulp(clf.coef_.ravel(), clf2.coef_.ravel())

--- a/lightning/impl/tests/test_fista.py
+++ b/lightning/impl/tests/test_fista.py
@@ -15,43 +15,43 @@ def bin_dense_train_data(bin_dense_train_data):
     return bin_dense, bin_target
 
 
-@pytest.mark.parametrize("data", [mult_dense_train_data, mult_sparse_train_data])
-def test_fista_multiclass_l1l2(data):
-    X, y = data
+@pytest.mark.parametrize("data", ["mult_dense_train_data", "mult_sparse_train_data"])
+def test_fista_multiclass_l1l2(data, request):
+    X, y = request.getfixturevalue(data)
     clf = FistaClassifier(max_iter=200, penalty="l1/l2", multiclass=True)
     clf.fit(X, y)
     np.testing.assert_almost_equal(clf.score(X, y), 0.99, 2)
 
 
-@pytest.mark.parametrize("data", [mult_dense_train_data, mult_sparse_train_data])
-def test_fista_multiclass_l1l2_log(data):
-    X, y = data
+@pytest.mark.parametrize("data", ["mult_dense_train_data", "mult_sparse_train_data"])
+def test_fista_multiclass_l1l2_log(data, request):
+    X, y = request.getfixturevalue(data)
     clf = FistaClassifier(max_iter=200, penalty="l1/l2", loss="log",
                           multiclass=True)
     clf.fit(X, y)
     np.testing.assert_almost_equal(clf.score(X, y), 0.90, 2)
 
 
-@pytest.mark.parametrize("data", [mult_dense_train_data, mult_sparse_train_data])
-def test_fista_multiclass_l1l2_log_margin(data):
-    X, y = data
+@pytest.mark.parametrize("data", ["mult_dense_train_data", "mult_sparse_train_data"])
+def test_fista_multiclass_l1l2_log_margin(data, request):
+    X, y = request.getfixturevalue(data)
     clf = FistaClassifier(max_iter=200, penalty="l1/l2", loss="log_margin",
                           multiclass=True)
     clf.fit(X, y)
     np.testing.assert_almost_equal(clf.score(X, y), 0.93, 2)
 
 
-@pytest.mark.parametrize("data", [mult_dense_train_data, mult_sparse_train_data])
-def test_fista_multiclass_l1(data):
-    X, y = data
+@pytest.mark.parametrize("data", ["mult_dense_train_data", "mult_sparse_train_data"])
+def test_fista_multiclass_l1(data, request):
+    X, y = request.getfixturevalue(data)
     clf = FistaClassifier(max_iter=200, penalty="l1", multiclass=True)
     clf.fit(X, y)
     np.testing.assert_almost_equal(clf.score(X, y), 0.98, 2)
 
 
-@pytest.mark.parametrize("data", [mult_dense_train_data, mult_sparse_train_data])
-def test_fista_multiclass_tv1d(data):
-    X, y = data
+@pytest.mark.parametrize("data", ["mult_dense_train_data", "mult_sparse_train_data"])
+def test_fista_multiclass_tv1d(data, request):
+    X, y = request.getfixturevalue(data)
     clf = FistaClassifier(max_iter=200, penalty="tv1d", multiclass=True)
     clf.fit(X, y)
     np.testing.assert_almost_equal(clf.score(X, y), 0.97, 2)
@@ -64,35 +64,35 @@ def test_fista_multiclass_tv1d(data):
             clf.coef_[i], np.mean(clf.coef_[i]) * np.ones(X.shape[1]))
 
 
-@pytest.mark.parametrize("data", [mult_dense_train_data, mult_sparse_train_data])
+@pytest.mark.parametrize("data", ["mult_dense_train_data", "mult_sparse_train_data"])
 @pytest.mark.parametrize("penalty", ["l1/l2", "l1"])
-def test_fista_multiclass_no_line_search(data, penalty):
-    X, y = data
+def test_fista_multiclass_no_line_search(data, penalty, request):
+    X, y = request.getfixturevalue(data)
     clf = FistaClassifier(max_iter=500, penalty=penalty, multiclass=True,
                           max_steps=0)
     clf.fit(X, y)
     np.testing.assert_almost_equal(clf.score(X, y), 0.94, 2)
 
 
-@pytest.mark.parametrize("data", [bin_dense_train_data, bin_sparse_train_data])
-def test_fista_bin_l1(data):
-    X, y = data
+@pytest.mark.parametrize("data", ["bin_dense_train_data", "bin_sparse_train_data"])
+def test_fista_bin_l1(data, request):
+    X, y = request.getfixturevalue(data)
     clf = FistaClassifier(max_iter=200, penalty="l1")
     clf.fit(X, y)
     np.testing.assert_almost_equal(clf.score(X, y), 1.0, 2)
 
 
-@pytest.mark.parametrize("data", [bin_dense_train_data, bin_sparse_train_data])
-def test_fista_bin_l1_no_line_search(data):
-    X, y = data
+@pytest.mark.parametrize("data", ["bin_dense_train_data", "bin_sparse_train_data"])
+def test_fista_bin_l1_no_line_search(data, request):
+    X, y = request.getfixturevalue(data)
     clf = FistaClassifier(max_iter=500, penalty="l1", max_steps=0)
     clf.fit(X, y)
     np.testing.assert_almost_equal(clf.score(X, y), 1.0, 2)
 
 
-@pytest.mark.parametrize("data", [mult_dense_train_data, mult_sparse_train_data])
-def test_fista_multiclass_trace(data):
-    X, y = data
+@pytest.mark.parametrize("data", ["mult_dense_train_data", "mult_sparse_train_data"])
+def test_fista_multiclass_trace(data, request):
+    X, y = request.getfixturevalue(data)
     clf = FistaClassifier(max_iter=100, penalty="trace", multiclass=True)
     clf.fit(X, y)
     np.testing.assert_almost_equal(clf.score(X, y), 0.96, 2)
@@ -172,11 +172,11 @@ def test_fista_regression_trace():
     np.testing.assert_almost_equal(error, 77.44, 2)
 
 
-@pytest.mark.parametrize("data", [bin_dense_train_data, bin_sparse_train_data])
-def test_fista_custom_prox(data):
+@pytest.mark.parametrize("data", ["bin_dense_train_data", "bin_sparse_train_data"])
+def test_fista_custom_prox(data, request):
     # test FISTA with a custom prox
     l1_pen = L1Penalty()
-    X, y = data
+    X, y = request.getfixturevalue(data)
     clf = FistaClassifier(max_iter=500, penalty="l1", max_steps=0)
     clf.fit(X, y)
 

--- a/lightning/impl/tests/test_penalty.py
+++ b/lightning/impl/tests/test_penalty.py
@@ -23,13 +23,13 @@ def project_simplex_bisection(v, z=1, tau=0.0001, max_iter=1000):
     return w
 
 
-@pytest.mark.parametrize("rng, z", [(100, 10),
-                                    (3, 1),
-                                    (2, 1)])
-def test_proj_simplex(rng, z):
+@pytest.mark.parametrize("size, z", [(100, 10),
+                                     (3, 1),
+                                     (2, 1)])
+def test_proj_simplex(size, z):
     rng = np.random.RandomState(0)
 
-    v = rng.rand(rng)
+    v = rng.rand(size)
     w = project_simplex(v, z=z)
     w2 = project_simplex_bisection(v, z=z, max_iter=100)
     np.testing.assert_array_almost_equal(w, w2, 3)

--- a/lightning/impl/tests/test_penalty.py
+++ b/lightning/impl/tests/test_penalty.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from lightning.impl.penalty import project_l1_ball, project_simplex
 
@@ -22,22 +23,15 @@ def project_simplex_bisection(v, z=1, tau=0.0001, max_iter=1000):
     return w
 
 
-def test_proj_simplex():
+@pytest.mark.parametrize("rng, z", [(100, 10),
+                                    (3, 1),
+                                    (2, 1)])
+def test_proj_simplex(rng, z):
     rng = np.random.RandomState(0)
 
-    v = rng.rand(100)
-    w = project_simplex(v, z=10)
-    w2 = project_simplex_bisection(v, z=10, max_iter=100)
-    np.testing.assert_array_almost_equal(w, w2, 3)
-
-    v = rng.rand(3)
-    w = project_simplex(v, z=1)
-    w2 = project_simplex_bisection(v, z=1, max_iter=100)
-    np.testing.assert_array_almost_equal(w, w2, 3)
-
-    v = rng.rand(2)
-    w = project_simplex(v, z=1)
-    w2 = project_simplex_bisection(v, z=1, max_iter=100)
+    v = rng.rand(rng)
+    w = project_simplex(v, z=z)
+    w2 = project_simplex_bisection(v, z=z, max_iter=100)
     np.testing.assert_array_almost_equal(w, w2, 3)
 
 

--- a/lightning/impl/tests/test_prank.py
+++ b/lightning/impl/tests/test_prank.py
@@ -1,16 +1,22 @@
 import numpy as np
+import pytest
 
 from sklearn.datasets import load_diabetes
 
 from lightning.ranking import PRank
 from lightning.ranking import KernelPRank
 
-bunch = load_diabetes()
-X, y = bunch.data, bunch.target
-y = np.round(y, decimals=-2)
+
+@pytest.fixture(scope="module")
+def train_data():
+    bunch = load_diabetes()
+    X, y = bunch.data, bunch.target
+    y = np.round(y, decimals=-2)
+    return X, y
 
 
-def test_prank():
+def test_prank(train_data):
+    X, y = train_data
     est = PRank(n_iter=10, shuffle=False, random_state=0)
     est.fit(X, y)
     np.testing.assert_almost_equal(est.score(X, y), 41.86, 2)
@@ -20,14 +26,16 @@ def test_prank():
     np.testing.assert_almost_equal(est.score(X, y), 71.04, 2)
 
 
-def test_prank_linear_kernel():
+def test_prank_linear_kernel(train_data):
+    X, y = train_data
     est = KernelPRank(kernel="linear", n_iter=10, shuffle=False,
                       random_state=0)
     est.fit(X, y)
     np.testing.assert_almost_equal(est.score(X, y), 41.86, 2)
 
 
-def test_prank_rbf_kernel():
+def test_prank_rbf_kernel(train_data):
+    X, y = train_data
     est = KernelPRank(kernel="rbf", gamma=100, n_iter=10, shuffle=False,
                       random_state=0)
     est.fit(X, y)

--- a/lightning/impl/tests/test_primal_cd.py
+++ b/lightning/impl/tests/test_primal_cd.py
@@ -240,9 +240,9 @@ def test_fit_squared_loss_l1(bin_dense_train_data):
     assert n_nz == 89
 
 
-@pytest.mark.parametrize("data", [mult_dense_train_data, mult_sparse_train_data])
-def test_l1l2_multiclass_log_loss(data):
-    X, y = data
+@pytest.mark.parametrize("data", ["mult_dense_train_data", "mult_sparse_train_data"])
+def test_l1l2_multiclass_log_loss(data, request):
+    X, y = request.getfixturevalue(data)
     clf = CDClassifier(penalty="l1/l2", loss="log", multiclass=True,
                        max_steps=30, max_iter=5, C=1.0, random_state=0)
     clf.fit(X, y)
@@ -277,9 +277,9 @@ def test_l1l2_multiclass_log_loss_no_linesearch(mult_sparse_train_data):
     assert nz == 297
 
 
-@pytest.mark.parametrize("data", [mult_dense_train_data, mult_sparse_train_data])
-def test_l1l2_multiclass_squared_hinge_loss(data):
-    X, y = data
+@pytest.mark.parametrize("data", ["mult_dense_train_data", "mult_sparse_train_data"])
+def test_l1l2_multiclass_squared_hinge_loss(data, request):
+    X, y = request.getfixturevalue(data)
     clf = CDClassifier(penalty="l1/l2", loss="squared_hinge",
                        multiclass=True,
                        max_iter=20, C=1.0, random_state=0)

--- a/lightning/impl/tests/test_primal_cd.py
+++ b/lightning/impl/tests/test_primal_cd.py
@@ -1,27 +1,21 @@
 import numpy as np
-import scipy.sparse as sp
+import pytest
 
 from sklearn.datasets import load_digits
 from sklearn.preprocessing import LabelBinarizer
 
-from lightning.impl.datasets.samples_generator import make_classification
 from lightning.impl.primal_cd import CDClassifier, CDRegressor
 from lightning.impl.tests.utils import check_predict_proba
 
 
-bin_dense, bin_target = make_classification(n_samples=200, n_features=100,
-                                            n_informative=5,
-                                            n_classes=2, random_state=0)
-
-mult_dense, mult_target = make_classification(n_samples=300, n_features=100,
-                                              n_informative=5,
-                                              n_classes=3, random_state=0)
-mult_csc = sp.csc_matrix(mult_dense)
-
-digit = load_digits(n_class=2)
+@pytest.fixture(scope="module")
+def train_data():
+    digit = load_digits(n_class=2)
+    return digit.data, digit.target
 
 
-def test_fit_linear_binary_l1r():
+def test_fit_linear_binary_l1r(bin_dense_train_data):
+    bin_dense, bin_target = bin_dense_train_data
     clf = CDClassifier(C=1.0, random_state=0, penalty="l1")
     clf.fit(bin_dense, bin_target)
     assert not hasattr(clf, 'predict_proba')
@@ -42,7 +36,8 @@ def test_fit_linear_binary_l1r():
     assert n_nz > n_nz2
 
 
-def test_fit_linear_binary_l1r_smooth_hinge():
+def test_fit_linear_binary_l1r_smooth_hinge(bin_dense_train_data):
+    bin_dense, bin_target = bin_dense_train_data
     clf = CDClassifier(C=1.0, loss="smooth_hinge", random_state=0, penalty="l1")
     clf.fit(bin_dense, bin_target)
     assert not hasattr(clf, 'predict_proba')
@@ -50,7 +45,8 @@ def test_fit_linear_binary_l1r_smooth_hinge():
     np.testing.assert_almost_equal(acc, 1.0)
 
 
-def test_fit_linear_binary_l1r_no_linesearch():
+def test_fit_linear_binary_l1r_no_linesearch(bin_dense_train_data):
+    bin_dense, bin_target = bin_dense_train_data
     clf = CDClassifier(C=1.0, selection="uniform", max_steps=0,
                        random_state=0, penalty="l1")
     clf.fit(bin_dense, bin_target)
@@ -58,15 +54,17 @@ def test_fit_linear_binary_l1r_no_linesearch():
     np.testing.assert_almost_equal(acc, 1.0)
 
 
-def test_l1r_shrinking():
-    for shrinking in (True, False):
-        clf = CDClassifier(C=0.5, penalty="l1", random_state=0,
-                           shrinking=shrinking)
-        clf.fit(bin_dense, bin_target)
-        assert clf.score(bin_dense, bin_target) == 1.0
+@pytest.mark.parametrize("shrinking", [True, False])
+def test_l1r_shrinking(bin_dense_train_data, shrinking):
+    bin_dense, bin_target = bin_dense_train_data
+    clf = CDClassifier(C=0.5, penalty="l1", random_state=0,
+                       shrinking=shrinking)
+    clf.fit(bin_dense, bin_target)
+    assert clf.score(bin_dense, bin_target) == 1.0
 
 
-def test_warm_start_l1r():
+def test_warm_start_l1r(bin_dense_train_data):
+    bin_dense, bin_target = bin_dense_train_data
     clf = CDClassifier(warm_start=True, random_state=0, penalty="l1")
 
     clf.C = 0.1
@@ -80,7 +78,8 @@ def test_warm_start_l1r():
     assert n_nz < n_nz2
 
 
-def test_warm_start_l1r_regression():
+def test_warm_start_l1r_regression(bin_dense_train_data):
+    bin_dense, bin_target = bin_dense_train_data
     clf = CDRegressor(warm_start=True, random_state=0, penalty="l1")
 
     clf.C = 0.1
@@ -94,7 +93,8 @@ def test_warm_start_l1r_regression():
     assert n_nz < n_nz2
 
 
-def test_fit_linear_binary_l1r_log_loss():
+def test_fit_linear_binary_l1r_log_loss(bin_dense_train_data):
+    bin_dense, bin_target = bin_dense_train_data
     clf = CDClassifier(C=1.0, random_state=0, penalty="l1", loss="log")
     clf.fit(bin_dense, bin_target)
     check_predict_proba(clf, bin_dense)
@@ -102,7 +102,8 @@ def test_fit_linear_binary_l1r_log_loss():
     np.testing.assert_almost_equal(acc, 0.995)
 
 
-def test_fit_linear_binary_l1r_log_loss_no_linesearch():
+def test_fit_linear_binary_l1r_log_loss_no_linesearch(bin_dense_train_data):
+    bin_dense, bin_target = bin_dense_train_data
     clf = CDClassifier(C=1.0, max_steps=0, random_state=0,
                        selection="uniform", penalty="l1", loss="log")
     clf.fit(bin_dense, bin_target)
@@ -110,14 +111,16 @@ def test_fit_linear_binary_l1r_log_loss_no_linesearch():
     np.testing.assert_almost_equal(acc, 0.995)
 
 
-def test_fit_linear_binary_l2r():
+def test_fit_linear_binary_l2r(bin_dense_train_data):
+    bin_dense, bin_target = bin_dense_train_data
     clf = CDClassifier(C=1.0, random_state=0, penalty="l2")
     clf.fit(bin_dense, bin_target)
     acc = clf.score(bin_dense, bin_target)
     np.testing.assert_almost_equal(acc, 1.0)
 
 
-def test_fit_linear_binary_l2r_log():
+def test_fit_linear_binary_l2r_log(bin_dense_train_data):
+    bin_dense, bin_target = bin_dense_train_data
     clf = CDClassifier(C=1.0, random_state=0, penalty="l2", loss="log",
                        max_iter=5)
     clf.fit(bin_dense, bin_target)
@@ -125,7 +128,8 @@ def test_fit_linear_binary_l2r_log():
     np.testing.assert_almost_equal(acc, 1.0)
 
 
-def test_fit_linear_binary_l2r_modified_huber():
+def test_fit_linear_binary_l2r_modified_huber(bin_dense_train_data):
+    bin_dense, bin_target = bin_dense_train_data
     clf = CDClassifier(C=1.0, random_state=0, penalty="l2",
                        loss="modified_huber")
     clf.fit(bin_dense, bin_target)
@@ -134,14 +138,16 @@ def test_fit_linear_binary_l2r_modified_huber():
     np.testing.assert_almost_equal(acc, 1.0)
 
 
-def test_fit_linear_multi_l2r():
+def test_fit_linear_multi_l2r(mult_dense_train_data):
+    mult_dense, mult_target = mult_dense_train_data
     clf = CDClassifier(C=1.0, random_state=0, penalty="l2")
     clf.fit(mult_dense, mult_target)
     acc = clf.score(mult_dense, mult_target)
     np.testing.assert_almost_equal(acc, 0.8833, 4)
 
 
-def test_warm_start_l2r():
+def test_warm_start_l2r(bin_dense_train_data):
+    bin_dense, bin_target = bin_dense_train_data
     clf = CDClassifier(warm_start=True, random_state=0, penalty="l2")
 
     clf.C = 0.1
@@ -153,29 +159,32 @@ def test_warm_start_l2r():
     np.testing.assert_almost_equal(clf.score(bin_dense, bin_target), 1.0)
 
 
-def test_debiasing_l1():
-    for warm_debiasing in (True, False):
-        clf = CDClassifier(penalty="l1", debiasing=True,
-                           warm_debiasing=warm_debiasing,
-                           C=0.05, Cd=1.0, max_iter=10, random_state=0)
-        clf.fit(bin_dense, bin_target)
-        assert clf.n_nonzero() == 22
-        np.testing.assert_almost_equal(clf.score(bin_dense, bin_target), 0.955, 3)
+@pytest.mark.parametrize("warm_debiasing", [True, False])
+def test_debiasing_l1(bin_dense_train_data, warm_debiasing):
+    bin_dense, bin_target = bin_dense_train_data
+    clf = CDClassifier(penalty="l1", debiasing=True,
+                       warm_debiasing=warm_debiasing,
+                       C=0.05, Cd=1.0, max_iter=10, random_state=0)
+    clf.fit(bin_dense, bin_target)
+    assert clf.n_nonzero() == 22
+    np.testing.assert_almost_equal(clf.score(bin_dense, bin_target), 0.955, 3)
 
 
-def test_debiasing_l1l2():
-    for warm_debiasing in (True, False):
-        clf = CDClassifier(penalty="l1/l2", loss="squared_hinge",
-                           multiclass=False,
-                           debiasing=True,
-                           warm_debiasing=warm_debiasing,
-                           max_iter=20, C=0.01, random_state=0)
-        clf.fit(mult_csc, mult_target)
-        assert clf.score(mult_csc, mult_target) > 0.75
-        assert clf.n_nonzero(percentage=True) == 0.08
+@pytest.mark.parametrize("warm_debiasing", [True, False])
+def test_debiasing_l1l2(mult_sparse_train_data, warm_debiasing):
+    mult_sparse, mult_target = mult_sparse_train_data
+    clf = CDClassifier(penalty="l1/l2", loss="squared_hinge",
+                       multiclass=False,
+                       debiasing=True,
+                       warm_debiasing=warm_debiasing,
+                       max_iter=20, C=0.01, random_state=0)
+    clf.fit(mult_sparse, mult_target)
+    assert clf.score(mult_sparse, mult_target) > 0.75
+    assert clf.n_nonzero(percentage=True) == 0.08
 
 
-def test_debiasing_warm_start():
+def test_debiasing_warm_start(bin_dense_train_data):
+    bin_dense, bin_target = bin_dense_train_data
     clf = CDClassifier(penalty="l1", max_iter=10,
                        warm_start=True, random_state=0)
     clf.C = 0.5
@@ -190,7 +199,8 @@ def test_debiasing_warm_start():
     np.testing.assert_almost_equal(clf.score(bin_dense, bin_target), 1.0)
 
 
-def test_empty_model():
+def test_empty_model(bin_dense_train_data):
+    bin_dense, bin_target = bin_dense_train_data
     clf = CDClassifier(C=1e-5, penalty="l1")
     clf.fit(bin_dense, bin_target)
     assert clf.n_nonzero() == 0
@@ -204,7 +214,8 @@ def test_empty_model():
     assert acc == 0.5
 
 
-def test_fit_squared_loss():
+def test_fit_squared_loss(bin_dense_train_data):
+    bin_dense, bin_target = bin_dense_train_data
     clf = CDClassifier(C=1.0, random_state=0, penalty="l2",
                        loss="squared", max_iter=100)
     clf.fit(bin_dense, bin_target)
@@ -215,7 +226,8 @@ def test_fit_squared_loss():
                                          clf.errors_.ravel())
 
 
-def test_fit_squared_loss_l1():
+def test_fit_squared_loss_l1(bin_dense_train_data):
+    bin_dense, bin_target = bin_dense_train_data
     clf = CDClassifier(C=0.5, random_state=0, penalty="l1",
                        loss="squared", max_iter=100, shrinking=False)
     clf.fit(bin_dense, bin_target)
@@ -228,76 +240,78 @@ def test_fit_squared_loss_l1():
     assert n_nz == 89
 
 
-def test_l1l2_multiclass_log_loss():
-    for data in (mult_dense, mult_csc):
-        clf = CDClassifier(penalty="l1/l2", loss="log", multiclass=True,
-                           max_steps=30, max_iter=5, C=1.0, random_state=0)
-        clf.fit(data, mult_target)
-        np.testing.assert_almost_equal(clf.score(data, mult_target), 0.8766, 3)
-        df = clf.decision_function(data)
-        sel = np.array([df[i, int(mult_target[i])] for i in range(df.shape[0])])
-        df -= sel[:, np.newaxis]
-        df = np.exp(df)
-        np.testing.assert_array_almost_equal(clf.errors_, df.T)
-        for i in range(data.shape[0]):
-            np.testing.assert_almost_equal(clf.errors_[mult_target[i], i], 1.0)
-        nz = np.sum(clf.coef_ != 0)
-        assert nz == 297
+@pytest.mark.parametrize("data", [mult_dense_train_data, mult_sparse_train_data])
+def test_l1l2_multiclass_log_loss(data):
+    X, y = data
+    clf = CDClassifier(penalty="l1/l2", loss="log", multiclass=True,
+                       max_steps=30, max_iter=5, C=1.0, random_state=0)
+    clf.fit(X, y)
+    np.testing.assert_almost_equal(clf.score(X, y), 0.8766, 3)
+    df = clf.decision_function(X)
+    sel = np.array([df[i, int(y[i])] for i in range(df.shape[0])])
+    df -= sel[:, np.newaxis]
+    df = np.exp(df)
+    np.testing.assert_array_almost_equal(clf.errors_, df.T)
+    for i in range(X.shape[0]):
+        np.testing.assert_almost_equal(clf.errors_[y[i], i], 1.0)
+    nz = np.sum(clf.coef_ != 0)
+    assert nz == 297
 
-        clf = CDClassifier(penalty="l1/l2", loss="log", multiclass=True,
-                           max_steps=30, max_iter=5, C=0.3, random_state=0)
-        clf.fit(data, mult_target)
-        np.testing.assert_almost_equal(clf.score(data, mult_target), 0.8566, 3)
-        nz = np.sum(clf.coef_ != 0)
-        assert nz == 213
-        assert nz % 3 == 0  # should be a multiple of n_classes
+    clf = CDClassifier(penalty="l1/l2", loss="log", multiclass=True,
+                       max_steps=30, max_iter=5, C=0.3, random_state=0)
+    clf.fit(X, y)
+    np.testing.assert_almost_equal(clf.score(X, y), 0.8566, 3)
+    nz = np.sum(clf.coef_ != 0)
+    assert nz == 213
+    assert nz % 3 == 0  # should be a multiple of n_classes
 
 
-def test_l1l2_multiclass_log_loss_no_linesearch():
-    data = mult_csc
+def test_l1l2_multiclass_log_loss_no_linesearch(mult_sparse_train_data):
+    mult_sparse, mult_target = mult_sparse_train_data
     clf = CDClassifier(penalty="l1/l2", loss="log", multiclass=True,
                        selection="uniform", max_steps=0,
                        max_iter=30, C=1.0, random_state=0)
-    clf.fit(data, mult_target)
-    np.testing.assert_almost_equal(clf.score(data, mult_target), 0.88, 3)
+    clf.fit(mult_sparse, mult_target)
+    np.testing.assert_almost_equal(clf.score(mult_sparse, mult_target), 0.88, 3)
     nz = np.sum(clf.coef_ != 0)
     assert nz == 297
 
 
-def test_l1l2_multiclass_squared_hinge_loss():
-    for data in (mult_dense, mult_csc):
-        clf = CDClassifier(penalty="l1/l2", loss="squared_hinge",
-                           multiclass=True,
-                           max_iter=20, C=1.0, random_state=0)
-        clf.fit(data, mult_target)
-        np.testing.assert_almost_equal(clf.score(data, mult_target), 0.913, 3)
-        df = clf.decision_function(data)
-        n_samples, n_vectors = df.shape
-        diff = np.zeros_like(clf.errors_)
-        for i in range(n_samples):
-            for k in range(n_vectors):
-                diff[k, i] = 1 - (df[i, mult_target[i]] - df[i, k])
-        np.testing.assert_array_almost_equal(clf.errors_, diff)
-        assert np.sum(clf.coef_ != 0) == 300
+@pytest.mark.parametrize("data", [mult_dense_train_data, mult_sparse_train_data])
+def test_l1l2_multiclass_squared_hinge_loss(data):
+    X, y = data
+    clf = CDClassifier(penalty="l1/l2", loss="squared_hinge",
+                       multiclass=True,
+                       max_iter=20, C=1.0, random_state=0)
+    clf.fit(X, y)
+    np.testing.assert_almost_equal(clf.score(X, y), 0.913, 3)
+    df = clf.decision_function(X)
+    n_samples, n_vectors = df.shape
+    diff = np.zeros_like(clf.errors_)
+    for i in range(n_samples):
+        for k in range(n_vectors):
+            diff[k, i] = 1 - (df[i, y[i]] - df[i, k])
+    np.testing.assert_array_almost_equal(clf.errors_, diff)
+    assert np.sum(clf.coef_ != 0) == 300
 
-        clf = CDClassifier(penalty="l1/l2", loss="squared_hinge",
-                           multiclass=True,
-                           max_iter=20, C=0.05, random_state=0)
-        clf.fit(data, mult_target)
-        np.testing.assert_almost_equal(clf.score(data, mult_target), 0.83, 3)
-        nz = np.sum(clf.coef_ != 0)
-        assert nz == 207
-        assert nz % 3 == 0  # should be a multiple of n_classes
+    clf = CDClassifier(penalty="l1/l2", loss="squared_hinge",
+                       multiclass=True,
+                       max_iter=20, C=0.05, random_state=0)
+    clf.fit(X, y)
+    np.testing.assert_almost_equal(clf.score(X, y), 0.83, 3)
+    nz = np.sum(clf.coef_ != 0)
+    assert nz == 207
+    assert nz % 3 == 0  # should be a multiple of n_classes
 
 
-def test_l1l2_multiclass_squared_hinge_loss_no_linesearch():
-    data = mult_csc
+def test_l1l2_multiclass_squared_hinge_loss_no_linesearch(mult_sparse_train_data):
+    mult_sparse, mult_target = mult_sparse_train_data
     clf = CDClassifier(penalty="l1/l2", loss="squared_hinge",
                        multiclass=True, shrinking=False, selection="uniform",
                        max_steps=0, max_iter=200, C=1.0, random_state=0)
-    clf.fit(data, mult_target)
-    np.testing.assert_almost_equal(clf.score(data, mult_target), 0.9166, 3)
-    df = clf.decision_function(data)
+    clf.fit(mult_sparse, mult_target)
+    np.testing.assert_almost_equal(clf.score(mult_sparse, mult_target), 0.9166, 3)
+    df = clf.decision_function(mult_sparse)
     n_samples, n_vectors = df.shape
     diff = np.zeros_like(clf.errors_)
     for i in range(n_samples):
@@ -309,15 +323,15 @@ def test_l1l2_multiclass_squared_hinge_loss_no_linesearch():
     clf = CDClassifier(penalty="l1/l2", loss="squared_hinge",
                        multiclass=True,
                        max_iter=20, C=0.05, random_state=0)
-    clf.fit(data, mult_target)
-    np.testing.assert_almost_equal(clf.score(data, mult_target), 0.83, 3)
+    clf.fit(mult_sparse, mult_target)
+    np.testing.assert_almost_equal(clf.score(mult_sparse, mult_target), 0.83, 3)
     nz = np.sum(clf.coef_ != 0)
     assert nz == 207
     assert nz % 3 == 0  # should be a multiple of n_classes
 
 
-
-def test_l1l2_multi_task_squared_hinge_loss():
+def test_l1l2_multi_task_squared_hinge_loss(mult_dense_train_data):
+    mult_dense, mult_target = mult_dense_train_data
     Y = LabelBinarizer(neg_label=-1).fit_transform(mult_target)
     clf = CDClassifier(penalty="l1/l2", loss="squared_hinge",
                        multiclass=False,
@@ -338,7 +352,8 @@ def test_l1l2_multi_task_squared_hinge_loss():
     assert nz == 231
 
 
-def test_l1l2_multi_task_log_loss():
+def test_l1l2_multi_task_log_loss(mult_dense_train_data):
+    mult_dense, mult_target = mult_dense_train_data
     clf = CDClassifier(penalty="l1/l2", loss="log",
                        multiclass=False,
                        max_steps=30,
@@ -347,7 +362,8 @@ def test_l1l2_multi_task_log_loss():
     np.testing.assert_almost_equal(clf.score(mult_dense, mult_target), 0.8633, 3)
 
 
-def test_l1l2_multi_task_square_loss():
+def test_l1l2_multi_task_square_loss(mult_dense_train_data):
+    mult_dense, mult_target = mult_dense_train_data
     clf = CDClassifier(penalty="l1/l2", loss="squared",
                        multiclass=False,
                        max_iter=20, C=5.0, random_state=0)
@@ -355,37 +371,41 @@ def test_l1l2_multi_task_square_loss():
     np.testing.assert_almost_equal(clf.score(mult_dense, mult_target), 0.8066, 3)
 
 
-def test_fit_reg_squared_l2():
+def test_fit_reg_squared_l2(train_data):
+    X, y = train_data
     clf = CDRegressor(C=1.0, random_state=0, penalty="l2",
                       loss="squared", max_iter=100)
-    clf.fit(digit.data, digit.target)
-    y_pred = (clf.predict(digit.data) > 0.5).astype(int)
-    acc = np.mean(digit.target == y_pred)
+    clf.fit(X, y)
+    y_pred = (clf.predict(X) > 0.5).astype(int)
+    acc = np.mean(y == y_pred)
     np.testing.assert_almost_equal(acc, 1.0, 3)
 
 
-def test_fit_reg_squared_l1():
+def test_fit_reg_squared_l1(train_data):
+    X, y = train_data
     clf = CDRegressor(C=1.0, random_state=0, penalty="l1",
                       loss="squared", max_iter=100)
-    clf.fit(digit.data, digit.target)
-    y_pred = (clf.predict(digit.data) > 0.5).astype(int)
-    acc = np.mean(digit.target == y_pred)
+    clf.fit(X, y)
+    y_pred = (clf.predict(X) > 0.5).astype(int)
+    acc = np.mean(y == y_pred)
     np.testing.assert_almost_equal(acc, 1.0, 3)
 
 
-def test_fit_reg_squared_multiple_outputs():
+def test_fit_reg_squared_multiple_outputs(train_data):
+    X, y = train_data
     reg = CDRegressor(C=1.0, random_state=0, penalty="l2",
                       loss="squared", max_iter=100)
-    Y = np.zeros((len(digit.target), 2))
-    Y[:, 0] = digit.target
-    Y[:, 1] = digit.target
-    reg.fit(digit.data, Y)
-    y_pred = reg.predict(digit.data)
-    assert y_pred.shape[0] == len(digit.target)
+    Y = np.zeros((len(y), 2))
+    Y[:, 0] = y
+    Y[:, 1] = y
+    reg.fit(X, Y)
+    y_pred = reg.predict(X)
+    assert y_pred.shape[0] == len(y)
     assert y_pred.shape[1] == 2
 
 
-def test_fit_reg_squared_multiple_outputs():
+def test_fit_reg_squared_multiple_outputs(mult_dense_train_data):
+    mult_dense, mult_target = mult_dense_train_data
     reg = CDRegressor(C=0.05, random_state=0, penalty="l1/l2",
                       loss="squared", max_iter=100)
     lb = LabelBinarizer()
@@ -396,19 +416,23 @@ def test_fit_reg_squared_multiple_outputs():
     np.testing.assert_almost_equal(reg.n_nonzero(percentage=True), 0.5)
 
 
-def test_multiclass_error_nongrouplasso():
-    for penalty in ['l1', 'l2']:
-        clf = CDClassifier(multiclass=True, penalty=penalty)
-        np.testing.assert_raises(NotImplementedError, clf.fit, mult_dense, mult_target)
+@pytest.mark.parametrize("penalty", ["l1", "l2"])
+def test_multiclass_error_nongrouplasso(mult_dense_train_data, penalty):
+    mult_dense, mult_target = mult_dense_train_data
+    clf = CDClassifier(multiclass=True, penalty=penalty)
+    with pytest.raises(NotImplementedError):
+        clf.fit(mult_dense, mult_target)
 
 
-def test_bin_classes():
+def test_bin_classes(bin_dense_train_data):
+    bin_dense, bin_target = bin_dense_train_data
     clf = CDClassifier()
     clf.fit(bin_dense, bin_target)
     assert list(clf.classes_) == [0, 1]
 
 
-def test_multiclass_classes():
+def test_multiclass_classes(mult_dense_train_data):
+    mult_dense, mult_target = mult_dense_train_data
     clf = CDClassifier()
     clf.fit(mult_dense, mult_target)
     assert list(clf.classes_) == [0, 1, 2]

--- a/lightning/impl/tests/test_primal_newton.py
+++ b/lightning/impl/tests/test_primal_newton.py
@@ -1,13 +1,10 @@
 import numpy as np
 
-from lightning.impl.datasets.samples_generator import make_classification
 from lightning.impl.primal_newton import KernelSVC
 
-bin_dense, bin_target = make_classification(n_samples=200, n_features=100,
-                                            n_informative=5,
-                                            n_classes=2, random_state=0)
 
-def test_kernel_svc():
+def test_kernel_svc(bin_dense_train_data):
+    bin_dense, bin_target = bin_dense_train_data
     clf = KernelSVC(kernel="rbf", gamma=0.1, random_state=0, verbose=0)
     clf.fit(bin_dense, bin_target)
     np.testing.assert_almost_equal(clf.score(bin_dense, bin_target), 1.0)

--- a/lightning/impl/tests/test_prox.py
+++ b/lightning/impl/tests/test_prox.py
@@ -1,6 +1,8 @@
 import numpy as np
+import pytest
 
 from lightning.impl import prox_fast
+
 
 def test_tv1_denoise():
     # test the prox of TV1D
@@ -19,11 +21,10 @@ def test_tv1_denoise():
         np.testing.assert_allclose(x, x.mean() * np.ones(n_features))
 
 
-def test_tv1d_dtype():
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_tv1d_dtype(dtype):
     # check that prox_tv1d preserve 32bit
-
     x = np.arange(5)
-    for dtype in (np.float32, np.float64):
-        y = x.astype(dtype, copy=True)
-        prox_fast.prox_tv1d(y, 0.01)
-        assert y.dtype == dtype
+    y = x.astype(dtype, copy=True)
+    prox_fast.prox_tv1d(y, 0.01)
+    assert y.dtype == dtype

--- a/lightning/impl/tests/test_sag.py
+++ b/lightning/impl/tests/test_sag.py
@@ -59,7 +59,7 @@ class Callback(object):
         self.obj.append(loss + regul)
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope='module')
 def callback(bin_train_data):
     cb = Callback(*bin_train_data)
     return cb
@@ -370,8 +370,9 @@ def test_no_reg_saga(bin_train_data):
                           PySAGAClassifier])
 def test_sag_callback(SAG_, bin_train_data, callback):
     X_bin, y_bin = bin_train_data
+    cb = callback
     clf = SAG_(loss="squared_hinge", eta=1e-3, max_iter=20,
-               random_state=0, callback=callback)
+               random_state=0, callback=cb)
     clf.fit(X_bin, y_bin)
     # its not a descent method, just check that most of
     # updates are decreasing the objective function

--- a/lightning/impl/tests/test_sag.py
+++ b/lightning/impl/tests/test_sag.py
@@ -444,18 +444,26 @@ def test_sag_sample_weights(train_data):
     np.testing.assert_array_almost_equal(clf1.coef_.ravel(), clf2.coef_.ravel(), decimal=6)
 
 
-@pytest.mark.parametrize("clf_adaptive, clf",
-                         [(SAGClassifier(eta='line-search', random_state=0, alpha=alpha),
-                           SAGClassifier(eta='auto', random_state=0, alpha=alpha)),
-                          (SAGAClassifier(eta='line-search', loss='log', random_state=0, alpha=alpha, max_iter=20),
-                           SAGAClassifier(eta='auto', loss='log', random_state=0, alpha=alpha, max_iter=20))])
-def test_sag_adaptive(clf_adaptive, clf):
+def test_sag_adaptive():
     # Check that the adaptive step size strategy yields the same
-    # solution as the non-adaptive
+    # solution as the non-adaptive"""
     np.random.seed(0)
     X = sparse.rand(100, 10, density=.5, random_state=0).tocsr()
     y = np.random.randint(0, high=2, size=100)
     for alpha in np.logspace(-3, 1, 5):
+        clf_adaptive = SAGClassifier(
+            eta='line-search', random_state=0, alpha=alpha)
         clf_adaptive.fit(X, y)
+        clf = SAGClassifier(
+            eta='auto', random_state=0, alpha=alpha)
+        clf.fit(X, y)
+        np.testing.assert_almost_equal(clf_adaptive.score(X, y), clf.score(X, y), 1)
+
+        clf_adaptive = SAGAClassifier(
+            eta='line-search', loss='log', random_state=0, alpha=alpha, max_iter=20)
+        clf_adaptive.fit(X, y)
+        assert np.isnan(clf_adaptive.coef_.sum()) == False
+        clf = SAGAClassifier(
+            eta='auto', loss='log', random_state=0, alpha=alpha, max_iter=20)
         clf.fit(X, y)
         np.testing.assert_almost_equal(clf_adaptive.score(X, y), clf.score(X, y), 1)

--- a/lightning/impl/tests/test_sag.py
+++ b/lightning/impl/tests/test_sag.py
@@ -141,8 +141,8 @@ class PySAGClassifier(BaseClassifier):
 
     def fit(self, X, y):
         self._set_label_transformers(y)
-        y = np.asfortranarray(self.label_binarizer_.transform(y),
-                              dtype=np.float64)
+        y_trans = np.asfortranarray(self.label_binarizer_.transform(y),
+                                    dtype=np.float64)
 
         if self.eta is None or self.eta == 'auto':
             eta = get_auto_step_size(
@@ -163,10 +163,10 @@ class PySAGClassifier(BaseClassifier):
                              "use `saga=True` or PySAGAClassifier.")
 
         if self.is_saga:
-            self.coef_ = _fit_saga(X, y, eta, self.alpha, loss,
+            self.coef_ = _fit_saga(X, y_trans, eta, self.alpha, loss,
                                    self.penalty, self.max_iter, self.rng)
         else:
-            self.coef_ = _fit_sag(X, y, eta, self.alpha, loss,
+            self.coef_ = _fit_sag(X, y_trans, eta, self.alpha, loss,
                                   self.max_iter, self.rng)
 
 

--- a/lightning/impl/tests/test_sdca.py
+++ b/lightning/impl/tests/test_sdca.py
@@ -1,98 +1,100 @@
 import numpy as np
-
-from sklearn.datasets import load_iris
+import pytest
 
 from lightning.classification import SDCAClassifier
 from lightning.regression import SDCARegressor
-from lightning.impl.tests.utils import check_predict_proba
 
 
-iris = load_iris()
-X, y = iris.data, iris.target
-
-X_bin = X[y <= 1]
-y_bin = y[y <= 1] * 2 - 1
-
-
-def test_sdca_hinge():
+def test_sdca_hinge(bin_train_data):
+    X_bin, y_bin = bin_train_data
     clf = SDCAClassifier(loss="hinge", random_state=0)
     clf.fit(X_bin, y_bin)
     assert not hasattr(clf, 'predict_proba')
     assert clf.score(X_bin, y_bin) == 1.0
 
 
-def test_sdca_hinge_multiclass():
+def test_sdca_hinge_multiclass(train_data):
+    X, y = train_data
     clf = SDCAClassifier(alpha=1e-2, max_iter=100, loss="hinge",
-                              random_state=0)
+                         random_state=0)
     clf.fit(X, y)
     np.testing.assert_almost_equal(clf.score(X, y), 0.933, 3)
 
 
-def test_sdca_squared():
+def test_sdca_squared(bin_train_data):
+    X_bin, y_bin = bin_train_data
     clf = SDCAClassifier(loss="squared", random_state=0)
     clf.fit(X_bin, y_bin)
     assert not hasattr(clf, 'predict_proba')
     assert clf.score(X_bin, y_bin) == 1.0
 
 
-def test_sdca_absolute():
+def test_sdca_absolute(bin_train_data):
+    X_bin, y_bin = bin_train_data
     clf = SDCAClassifier(loss="absolute", random_state=0)
     clf.fit(X_bin, y_bin)
     assert not hasattr(clf, 'predict_proba')
     assert clf.score(X_bin, y_bin) == 1.0
 
 
-def test_sdca_hinge_elastic():
+def test_sdca_hinge_elastic(bin_train_data):
+    X_bin, y_bin = bin_train_data
     clf = SDCAClassifier(alpha=0.5, l1_ratio=0.85, loss="hinge",
-                              random_state=0)
+                         random_state=0)
     clf.fit(X_bin, y_bin)
     assert clf.score(X_bin, y_bin) == 1.0
 
 
-def test_sdca_smooth_hinge_elastic():
+def test_sdca_smooth_hinge_elastic(bin_train_data):
+    X_bin, y_bin = bin_train_data
     clf = SDCAClassifier(alpha=0.5, l1_ratio=0.85, loss="smooth_hinge",
-                              random_state=0)
+                         random_state=0)
     clf.fit(X_bin, y_bin)
     assert not hasattr(clf, 'predict_proba')
     assert clf.score(X_bin, y_bin) == 1.0
 
 
-def test_sdca_squared_hinge_elastic():
+def test_sdca_squared_hinge_elastic(bin_train_data):
+    X_bin, y_bin = bin_train_data
     clf = SDCAClassifier(alpha=0.5, l1_ratio=0.85, loss="squared_hinge",
-                              random_state=0)
+                         random_state=0)
     clf.fit(X_bin, y_bin)
     assert clf.score(X_bin, y_bin) == 1.0
 
 
-def test_sdca_hinge_l1_only():
+def test_sdca_hinge_l1_only(bin_train_data):
+    X_bin, y_bin = bin_train_data
     clf = SDCAClassifier(alpha=0.5, l1_ratio=1.0, loss="hinge", tol=1e-2,
-                              max_iter=200, random_state=0)
+                         max_iter=200, random_state=0)
     clf.fit(X_bin, y_bin)
     assert clf.score(X_bin, y_bin) == 1.0
 
 
-def test_sdca_smooth_hinge_l1_only():
+def test_sdca_smooth_hinge_l1_only(bin_train_data):
+    X_bin, y_bin = bin_train_data
     clf = SDCAClassifier(alpha=0.5, l1_ratio=1.0, loss="smooth_hinge",
-                              tol=1e-2, max_iter=200, random_state=0)
+                         tol=1e-2, max_iter=200, random_state=0)
     clf.fit(X_bin, y_bin)
     assert clf.score(X_bin, y_bin) == 1.0
 
 
-def test_sdca_squared_l1_only():
+def test_sdca_squared_l1_only(bin_train_data):
+    X_bin, y_bin = bin_train_data
     clf = SDCAClassifier(alpha=0.5, l1_ratio=1.0, loss="squared", tol=1e-2,
-                              max_iter=100, random_state=0)
+                         max_iter=100, random_state=0)
     clf.fit(X_bin, y_bin)
     assert clf.score(X_bin, y_bin) == 1.0
 
 
-def test_sdca_absolute_l1_only():
+def test_sdca_absolute_l1_only(bin_train_data):
+    X_bin, y_bin = bin_train_data
     clf = SDCAClassifier(alpha=0.5, l1_ratio=1.0, loss="absolute",
-                              tol=1e-2, max_iter=200, random_state=0)
+                         tol=1e-2, max_iter=200, random_state=0)
     clf.fit(X_bin, y_bin)
     assert clf.score(X_bin, y_bin) == 1.0
 
 
-def test_sdca_callback():
+def test_sdca_callback(bin_train_data):
     class Callback(object):
 
         def __init__(self, X, y):
@@ -104,30 +106,33 @@ def test_sdca_callback():
             score = clf.score(self.X, self.y)
             self.acc.append(score)
 
+    X_bin, y_bin = bin_train_data
     cb = Callback(X_bin, y_bin)
     clf = SDCAClassifier(alpha=0.5, l1_ratio=0.85, loss="hinge",
-                              callback=cb, random_state=0)
+                         callback=cb, random_state=0)
     clf.fit(X_bin, y_bin)
     assert cb.acc[0] == 0.5
     assert cb.acc[-1] == 1.0
 
 
-def test_bin_classes():
+def test_bin_classes(bin_train_data):
+    X_bin, y_bin = bin_train_data
     clf = SDCAClassifier()
     clf.fit(X_bin, y_bin)
     assert list(clf.classes_) == [-1, 1]
 
 
-def test_multiclass_classes():
+def test_multiclass_classes(train_data):
+    X, y = train_data
     clf = SDCAClassifier()
     clf.fit(X, y)
     assert list(clf.classes_) == [0, 1, 2]
 
 
-def test_sdca_regression():
-    for loss in ("squared", "absolute"):
-        reg = SDCARegressor(loss=loss)
-        reg.fit(X_bin, y_bin)
-        y_pred = np.sign(reg.predict(X_bin))
-        assert np.mean(y_bin == y_pred) == 1.0
-
+@pytest.mark.parametrize("loss", ["squared", "absolute"])
+def test_sdca_regression(bin_train_data, loss):
+    X_bin, y_bin = bin_train_data
+    reg = SDCARegressor(loss=loss)
+    reg.fit(X_bin, y_bin)
+    y_pred = np.sign(reg.predict(X_bin))
+    assert np.mean(y_bin == y_pred) == 1.0

--- a/lightning/impl/tests/test_sgd.py
+++ b/lightning/impl/tests/test_sgd.py
@@ -23,7 +23,7 @@ def reg_nn_train_data():
     return X, y
 
 
-@pytest.mark.parametrize("data", [bin_dense_train_data, bin_sparse_train_data])
+@pytest.mark.parametrize("data", ["bin_dense_train_data", "bin_sparse_train_data"])
 @pytest.mark.parametrize("clf", [SGDClassifier(random_state=0, loss="hinge",
                                                fit_intercept=True, learning_rate="pegasos"),
                                  SGDClassifier(random_state=0, loss="hinge",
@@ -39,8 +39,8 @@ def reg_nn_train_data():
                                                fit_intercept=True, learning_rate="constant"),
                                  SGDClassifier(random_state=0, loss="modified_huber",
                                                fit_intercept=True, learning_rate="constant")])
-def test_binary_linear_sgd(data, clf):
-    X, y = data
+def test_binary_linear_sgd(data, clf, request):
+    X, y = request.getfixturevalue(data)
     clf.fit(X, y)
     assert clf.score(X, y) > 0.934
     assert list(clf.classes_) == [0, 1]
@@ -58,29 +58,29 @@ def test_multiclass_sgd(mult_dense_train_data):
     assert list(clf.classes_) == [0, 1, 2]
 
 
-@pytest.mark.parametrize("data", [mult_dense_train_data, mult_sparse_train_data])
+@pytest.mark.parametrize("data", ["mult_dense_train_data", "mult_sparse_train_data"])
 @pytest.mark.parametrize("fit_intercept", [True, False])
-def test_multiclass_hinge_sgd(data, fit_intercept):
-    X, y = data
+def test_multiclass_hinge_sgd(data, fit_intercept, request):
+    X, y = request.getfixturevalue(data)
     clf = SGDClassifier(loss="hinge", multiclass=True,
                         fit_intercept=fit_intercept, random_state=0)
     clf.fit(X, y)
     assert clf.score(X, y) > 0.78
 
 
-@pytest.mark.parametrize("data", [mult_dense_train_data, mult_sparse_train_data])
-def test_multiclass_hinge_sgd_l1l2(data):
-    X, y = data
+@pytest.mark.parametrize("data", ["mult_dense_train_data", "mult_sparse_train_data"])
+def test_multiclass_hinge_sgd_l1l2(data, request):
+    X, y = request.getfixturevalue(data)
     clf = SGDClassifier(loss="hinge", penalty="l1/l2",
                         multiclass=True, random_state=0)
     clf.fit(X, y)
     assert clf.score(X, y) > 0.75
 
 
-@pytest.mark.parametrize("data", [mult_dense_train_data, mult_sparse_train_data])
+@pytest.mark.parametrize("data", ["mult_dense_train_data", "mult_sparse_train_data"])
 @pytest.mark.parametrize("fit_intercept", [True, False])
-def test_multiclass_squared_hinge_sgd(data, fit_intercept):
-    X, y = data
+def test_multiclass_squared_hinge_sgd(data, fit_intercept, request):
+    X, y = request.getfixturevalue(data)
     clf = SGDClassifier(loss="squared_hinge", multiclass=True,
                         learning_rate="constant", eta0=1e-3,
                         fit_intercept=fit_intercept, random_state=0)
@@ -88,10 +88,10 @@ def test_multiclass_squared_hinge_sgd(data, fit_intercept):
     assert clf.score(X, y) > 0.78
 
 
-@pytest.mark.parametrize("data", [mult_dense_train_data, mult_sparse_train_data])
+@pytest.mark.parametrize("data", ["mult_dense_train_data", "mult_sparse_train_data"])
 @pytest.mark.parametrize("fit_intercept", [True, False])
-def test_multiclass_log_sgd(data, fit_intercept):
-    X, y = data
+def test_multiclass_log_sgd(data, fit_intercept, request):
+    X, y = request.getfixturevalue(data)
     clf = SGDClassifier(loss="log", multiclass=True,
                         fit_intercept=fit_intercept,
                         random_state=0)

--- a/lightning/impl/tests/test_sgd.py
+++ b/lightning/impl/tests/test_sgd.py
@@ -1,101 +1,106 @@
 import numpy as np
-import scipy.sparse as sp
+import pytest
 
 from sklearn.datasets import make_regression
 
-from lightning.impl.datasets.samples_generator import make_classification
 from lightning.impl.datasets.samples_generator import make_nn_regression
 from lightning.impl.sgd import SGDClassifier
 from lightning.impl.sgd import SGDRegressor
 from lightning.impl.tests.utils import check_predict_proba
 
 
-bin_dense, bin_target = make_classification(n_samples=200, n_features=100,
-                                            n_informative=5,
-                                            n_classes=2, random_state=0)
-
-mult_dense, mult_target = make_classification(n_samples=300, n_features=100,
-                                              n_informative=5,
-                                              n_classes=3, random_state=0)
-
-bin_csr = sp.csr_matrix(bin_dense)
-mult_csr = sp.csr_matrix(mult_dense)
+@pytest.fixture(scope="module")
+def reg_train_data():
+    X, y = make_regression(n_samples=100, n_features=10, n_informative=8,
+                           random_state=0)
+    return X, y
 
 
-def test_binary_linear_sgd():
-    for data in (bin_dense, bin_csr):
-        for clf in (SGDClassifier(random_state=0, loss="hinge",
-                                  fit_intercept=True, learning_rate="pegasos"),
-                    SGDClassifier(random_state=0, loss="hinge",
-                                  fit_intercept=False, learning_rate="pegasos"),
-                    SGDClassifier(random_state=0, loss="hinge",
-                                  fit_intercept=True, learning_rate="invscaling"),
-                    SGDClassifier(random_state=0, loss="hinge",
-                                  fit_intercept=True, learning_rate="constant"),
-                    SGDClassifier(random_state=0, loss="squared_hinge",
-                                  eta0=1e-2,
-                                  fit_intercept=True, learning_rate="constant"),
-                    SGDClassifier(random_state=0, loss="log",
-                                  fit_intercept=True, learning_rate="constant"),
-                    SGDClassifier(random_state=0, loss="modified_huber",
-                                  fit_intercept=True, learning_rate="constant"),
-                    ):
-            clf.fit(data, bin_target)
-            assert clf.score(data, bin_target) > 0.934
-            assert list(clf.classes_) == [0, 1]
-            if clf.loss in ('log', 'modified_huber'):
-                check_predict_proba(clf, data)
-            else:
-                assert not hasattr(clf, 'predict_proba')
+@pytest.fixture(scope="module")
+def reg_nn_train_data():
+    X, y, _ = make_nn_regression(n_samples=100, n_features=10, n_informative=8,
+                                 random_state=0)
+    return X, y
 
 
-def test_multiclass_sgd():
+@pytest.mark.parametrize("data", [bin_dense_train_data, bin_sparse_train_data])
+@pytest.mark.parametrize("clf", [SGDClassifier(random_state=0, loss="hinge",
+                                               fit_intercept=True, learning_rate="pegasos"),
+                                 SGDClassifier(random_state=0, loss="hinge",
+                                               fit_intercept=False, learning_rate="pegasos"),
+                                 SGDClassifier(random_state=0, loss="hinge",
+                                               fit_intercept=True, learning_rate="invscaling"),
+                                 SGDClassifier(random_state=0, loss="hinge",
+                                               fit_intercept=True, learning_rate="constant"),
+                                 SGDClassifier(random_state=0, loss="squared_hinge",
+                                               eta0=1e-2,
+                                               fit_intercept=True, learning_rate="constant"),
+                                 SGDClassifier(random_state=0, loss="log",
+                                               fit_intercept=True, learning_rate="constant"),
+                                 SGDClassifier(random_state=0, loss="modified_huber",
+                                               fit_intercept=True, learning_rate="constant")])
+def test_binary_linear_sgd(data, clf):
+    X, y = data
+    clf.fit(X, y)
+    assert clf.score(X, y) > 0.934
+    assert list(clf.classes_) == [0, 1]
+    if clf.loss in {'log', 'modified_huber'}:
+        check_predict_proba(clf, X)
+    else:
+        assert not hasattr(clf, 'predict_proba')
+
+
+def test_multiclass_sgd(mult_dense_train_data):
+    mult_dense, mult_target = mult_dense_train_data
     clf = SGDClassifier(random_state=0)
     clf.fit(mult_dense, mult_target)
     assert clf.score(mult_dense, mult_target) > 0.80
     assert list(clf.classes_) == [0, 1, 2]
 
 
-def test_multiclass_hinge_sgd():
-    for data in (mult_dense, mult_csr):
-        for fit_intercept in (True, False):
-            clf = SGDClassifier(loss="hinge", multiclass=True,
-                                fit_intercept=fit_intercept, random_state=0)
-            clf.fit(data, mult_target)
-            assert clf.score(data, mult_target) > 0.78
+@pytest.mark.parametrize("data", [mult_dense_train_data, mult_sparse_train_data])
+@pytest.mark.parametrize("fit_intercept", [True, False])
+def test_multiclass_hinge_sgd(data, fit_intercept):
+    X, y = data
+    clf = SGDClassifier(loss="hinge", multiclass=True,
+                        fit_intercept=fit_intercept, random_state=0)
+    clf.fit(X, y)
+    assert clf.score(X, y) > 0.78
 
 
-def test_multiclass_hinge_sgd_l1l2():
-    for data in (mult_dense, mult_csr):
-        clf = SGDClassifier(loss="hinge", penalty="l1/l2",
-                            multiclass=True, random_state=0)
-        clf.fit(data, mult_target)
-        assert clf.score(data, mult_target) > 0.75
+@pytest.mark.parametrize("data", [mult_dense_train_data, mult_sparse_train_data])
+def test_multiclass_hinge_sgd_l1l2(data):
+    X, y = data
+    clf = SGDClassifier(loss="hinge", penalty="l1/l2",
+                        multiclass=True, random_state=0)
+    clf.fit(X, y)
+    assert clf.score(X, y) > 0.75
 
 
-def test_multiclass_squared_hinge_sgd():
-    for data in (mult_dense, mult_csr):
-        for fit_intercept in (True, False):
-            clf = SGDClassifier(loss="squared_hinge", multiclass=True,
-                                learning_rate="constant", eta0=1e-3,
-                                fit_intercept=fit_intercept, random_state=0)
-            clf.fit(data, mult_target)
-            assert clf.score(data, mult_target) > 0.78
+@pytest.mark.parametrize("data", [mult_dense_train_data, mult_sparse_train_data])
+@pytest.mark.parametrize("fit_intercept", [True, False])
+def test_multiclass_squared_hinge_sgd(data, fit_intercept):
+    X, y = data
+    clf = SGDClassifier(loss="squared_hinge", multiclass=True,
+                        learning_rate="constant", eta0=1e-3,
+                        fit_intercept=fit_intercept, random_state=0)
+    clf.fit(X, y)
+    assert clf.score(X, y) > 0.78
 
 
-def test_multiclass_log_sgd():
-    for data in (mult_dense, mult_csr):
-        for fit_intercept in (True, False):
-            clf = SGDClassifier(loss="log", multiclass=True,
-                                fit_intercept=fit_intercept,
-                                random_state=0)
-            clf.fit(data, mult_target)
-            assert clf.score(data, mult_target) > 0.78
+@pytest.mark.parametrize("data", [mult_dense_train_data, mult_sparse_train_data])
+@pytest.mark.parametrize("fit_intercept", [True, False])
+def test_multiclass_log_sgd(data, fit_intercept):
+    X, y = data
+    clf = SGDClassifier(loss="log", multiclass=True,
+                        fit_intercept=fit_intercept,
+                        random_state=0)
+    clf.fit(X, y)
+    assert clf.score(X, y) > 0.78
 
 
-def test_regression_squared_loss():
-    X, y = make_regression(n_samples=100, n_features=10, n_informative=8,
-                           random_state=0)
+def test_regression_squared_loss(reg_train_data):
+    X, y = reg_train_data
     reg = SGDRegressor(loss="squared", penalty="l2", learning_rate="constant",
                        eta0=1e-2, random_state=0)
 
@@ -104,23 +109,20 @@ def test_regression_squared_loss():
     np.testing.assert_almost_equal(np.mean((pred - y) ** 2), 4.749, 3)
 
 
-def test_regression_squared_loss_nn_l1():
-    X, y, _ = make_nn_regression(n_samples=100, n_features=10, n_informative=8,
-                                 random_state=0)
+@pytest.mark.parametrize("alpha", [0, 1e-6])
+def test_regression_squared_loss_nn_l1(reg_nn_train_data, alpha):
+    X, y = reg_nn_train_data
+    reg = SGDRegressor(loss="squared", penalty="nn", learning_rate="constant",
+                       eta0=1e-1, alpha=alpha, random_state=0)
 
-    for alpha in (0, 1e-6):
-        reg = SGDRegressor(loss="squared", penalty="nn", learning_rate="constant",
-                           eta0=1e-1, alpha=alpha, random_state=0)
-
-        reg.fit(X, y)
-        pred = reg.predict(X)
-        np.testing.assert_almost_equal(np.mean((pred - y) ** 2), 0.016, 3)
-        assert (reg.coef_ >= 0).all()
+    reg.fit(X, y)
+    pred = reg.predict(X)
+    np.testing.assert_almost_equal(np.mean((pred - y) ** 2), 0.016, 3)
+    assert (reg.coef_ >= 0).all()
 
 
-def test_regression_squared_loss_nn_l2():
-    X, y, _ = make_nn_regression(n_samples=100, n_features=10, n_informative=8,
-                                 random_state=0)
+def test_regression_squared_loss_nn_l2(reg_nn_train_data):
+    X, y = reg_nn_train_data
 
     reg = SGDRegressor(loss="squared", penalty="nnl2", learning_rate="constant",
                        eta0=1e-1, alpha=1e-4, random_state=0)
@@ -132,9 +134,8 @@ def test_regression_squared_loss_nn_l2():
     assert (reg.coef_ >= 0).all()
 
 
-def test_regression_squared_loss_multiple_output():
-    X, y = make_regression(n_samples=100, n_features=10, n_informative=8,
-                           random_state=0)
+def test_regression_squared_loss_multiple_output(reg_train_data):
+    X, y = reg_train_data
     reg = SGDRegressor(loss="squared", penalty="l2", learning_rate="constant",
                        eta0=1e-2, random_state=0, max_iter=10)
     Y = np.zeros((len(y), 2))
@@ -143,4 +144,3 @@ def test_regression_squared_loss_multiple_output():
     reg.fit(X, Y)
     pred = reg.predict(X)
     np.testing.assert_almost_equal(np.mean((pred - Y) ** 2), 4.397, 3)
-

--- a/lightning/impl/tests/test_svrg.py
+++ b/lightning/impl/tests/test_svrg.py
@@ -1,26 +1,18 @@
 import numpy as np
 
-from sklearn.datasets import load_iris
-
 from lightning.classification import SVRGClassifier
 from lightning.regression import SVRGRegressor
-from lightning.impl.sgd_fast import SmoothHinge
-
-iris = load_iris()
-X, y = iris.data, iris.target
-
-X_bin = X[y <= 1]
-y_bin = y[y <= 1] * 2 - 1
 
 
-def test_svrg():
+def test_svrg(bin_train_data):
+    X_bin, y_bin = bin_train_data
     clf = SVRGClassifier(eta=1e-3, max_iter=20, random_state=0, verbose=0)
     clf.fit(X_bin, y_bin)
     assert not hasattr(clf, 'predict_proba')
     assert clf.score(X_bin, y_bin) == 1.0
 
 
-def test_svrg_callback():
+def test_svrg_callback(bin_train_data):
     class Callback(object):
 
         def __init__(self, X, y):
@@ -36,6 +28,7 @@ def test_svrg_callback():
             regul = 0.5 * clf.alpha * np.dot(coef, coef)
             self.obj.append(loss + regul)
 
+    X_bin, y_bin = bin_train_data
     cb = Callback(X_bin, y_bin)
     clf = SVRGClassifier(loss="squared_hinge", eta=1e-3, max_iter=20,
                          random_state=0, callback=cb)
@@ -43,20 +36,23 @@ def test_svrg_callback():
     assert np.all(np.diff(cb.obj) <= 0)
 
 
-def test_svrg_regression():
+def test_svrg_regression(bin_train_data):
+    X_bin, y_bin = bin_train_data
     reg = SVRGRegressor(eta=1e-3)
     reg.fit(X_bin, y_bin)
     y_pred = np.sign(reg.predict(X_bin))
     assert np.mean(y_bin == y_pred) == 1.0
 
 
-def test_bin_classes():
+def test_bin_classes(bin_train_data):
+    X_bin, y_bin = bin_train_data
     clf = SVRGClassifier()
     clf.fit(X_bin, y_bin)
     assert list(clf.classes_) == [-1, 1]
 
 
-def test_multiclass_classes():
+def test_multiclass_classes(train_data):
+    X, y = train_data
     clf = SVRGClassifier()
     clf.fit(X, y)
     assert list(clf.classes_) == [0, 1, 2]


### PR DESCRIPTION
Use pytest fixtures to parametrize existing tests. It allows to remove duplicated code (mainly, dataset generations), speed up tests, increase code readability. Also it improves test logs readability (see screenshot below), note additional square brackets in a test title.

![image](https://user-images.githubusercontent.com/25141164/148848001-5ea835c2-ff71-454d-8b5a-7711800963f4.png)



Sorry, this PR looks quite huge for review, but you can hide whitespace changes and leave only meaningful ones (they are all similar across files).

![image](https://user-images.githubusercontent.com/25141164/148849615-234de9df-c97e-4e9a-bfe9-50cccdcd335d.png)
