### PR TITLE
Exclude egg files during uploading PyPI release and allow `dev` and `post` release tags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -137,4 +137,4 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
         run: |
           pip install twine
-          twine upload dist/*
+          twine upload dist/*.whl dist/*.tar.gz

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+*'
   pull_request:
     branches:
       - master


### PR DESCRIPTION
Refer to https://www.python.org/dev/peps/pep-0440/#version-scheme.