### PR TITLE
Fix PyPI uploads

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -137,4 +137,5 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
         run: |
           pip install twine
-          twine upload dist/*.whl dist/*.tar.gz
+          rm -f dist/*.egg
+          twine upload dist/*


### PR DESCRIPTION
Simply remove `.egg` files before creating PyPI release to avoid specific globbing patterns fail in some jobs.