### PR TITLE
chore: provide python 3.11 support for generated wheels

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,7 @@ jobs:
           - '3.8'
           - '3.9'
           - '3.10'
+          - '3.11'
         python_arch:
           - x64
         include:


### PR DESCRIPTION
provide python 3.11 support for generated wheels on pypi